### PR TITLE
refactor: remove materialize

### DIFF
--- a/ibis_substrait/compiler/core.py
+++ b/ibis_substrait/compiler/core.py
@@ -76,7 +76,7 @@ class SubstraitCompiler:
         """Construct a Substrait plan from an ibis table expression."""
         from .translate import translate
 
-        expr_schema = expr.materialize().schema()
+        expr_schema = expr.schema()
         rel = stp.PlanRel(
             root=stalg.RelRoot(
                 input=translate(expr.op(), expr, self),


### PR DESCRIPTION
Removes the one call to `materialize` to maintain compatibility with upstream