### PR TITLE
fix(extract): substrait function argument ordering

### DIFF
--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -34,6 +34,6 @@ SUBSTRAIT_IBIS_OP_MAPPING = {
     v: getattr(ops, k) for k, v in IBIS_SUBSTRAIT_OP_MAPPING.items()
 }
 # override when reversing many-to-one mappings
-SUBSTRAIT_IBIS_OP_MAPPING["extract"] = lambda table, span: getattr(
+SUBSTRAIT_IBIS_OP_MAPPING["extract"] = lambda span, table: getattr(
     ops, f"Extract{span.capitalize()}"
 )(table)

--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -968,16 +968,18 @@ def _extractdatefield(
     compiler: SubstraitCompiler,
     **kwargs: Any,
 ) -> stalg.Expression:
+    # e.g. "ExtractYear" -> "YEAR"
+    span = type(op).__name__[len("Extract") :].upper()
+    args = (
+        translate(arg, compiler, **kwargs)
+        for arg in op.args
+        if isinstance(arg, ir.Expr)
+    )
+
     scalar_func = stalg.Expression.ScalarFunction(
         function_reference=compiler.function_id(expr),
         output_type=translate(expr.type()),
-        args=[
-            translate(arg, compiler, **kwargs)
-            for arg in op.args
-            if isinstance(arg, ir.Expr)
-        ],
     )
-    # e.g. "ExtractYear" -> "YEAR"
-    span = type(op).__name__.lstrip("Extract").upper()
     scalar_func.args.add(enum=stalg.Expression.Enum(specified=span))
+    scalar_func.args.extend(args)
     return stalg.Expression(scalar_function=scalar_func)


### PR DESCRIPTION
According to the spec, you cannot have the function option argument
specified after a "regular" argument.

Definitely time to add the validator to our CI runs