### PR TITLE
fix(translate): use FunctionArgument in ops.Count translation

### DIFF
--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -551,7 +551,9 @@ def _count(
     translated_args = []
     arg = op.arg
     if not isinstance(arg, ir.TableExpr):
-        translated_args.append(translate(arg, compiler, **kwargs))
+        translated_args.append(
+            stalg.FunctionArgument(value=translate(arg, compiler, **kwargs))
+        )
     return stalg.AggregateFunction(
         function_reference=compiler.function_id(expr),
         arguments=translated_args,

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -301,3 +301,25 @@ def test_nested_struct_field_access(compiler):
     )
     result = translate(expr, compiler)
     assert result == expected
+
+
+def test_function_argument_usage(compiler):
+    t = ibis.table([("a", "int64")], name="t")
+    expr = t.a.count()
+
+    result = translate(expr, compiler)
+    # Check that there is an `arguments` field
+    # and that it has the expected `value`
+    expected = json_format.ParseDict(
+        {
+            "value": {
+                "selection": {
+                    "direct_reference": {"struct_field": {}},
+                    "root_reference": {},
+                },
+            },
+        },
+        stalg.FunctionArgument(),
+    )
+
+    assert result.arguments[0] == expected


### PR DESCRIPTION
Follow up to #289 -- missed one specification of `FunctionArgument`