### PR TITLE
fix: always calculate child rel field offsets for join predicates

### DIFF
--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -798,6 +798,7 @@ def join(
     compiler: SubstraitCompiler,
     **kwargs: Any,
 ) -> stalg.Rel:
+    child_rel_field_offsets = kwargs.pop("child_rel_field_offsets", None)
     return stalg.Rel(
         join=stalg.JoinRel(
             left=translate(op.left, compiler, **kwargs),
@@ -805,6 +806,8 @@ def join(
             expression=translate(
                 functools.reduce(operator.and_, op.predicates),
                 compiler,
+                child_rel_field_offsets=child_rel_field_offsets
+                or _get_child_relation_field_offsets(expr),
                 **kwargs,
             ),
             type=_translate_join_type(op),

--- a/ibis_substrait/tests/compiler/test_tpch.py
+++ b/ibis_substrait/tests/compiler/test_tpch.py
@@ -689,7 +689,7 @@ TPC_H = [
     pytest.param(
         lazy_fixture("tpc_h15"),
         marks=pytest.mark.xfail(
-            raises=AssertionError, reason="non-empty child offsets"
+            raises=KeyError, reason="TableArrayView not implemented"
         ),
     ),
     pytest.param(


### PR DESCRIPTION
The confusion for me has been the location of the `field` lookup,
referenced in the
`expression->scalar_function->arguments->value->selection->direct_reference->struct_field`

Where is the list of columns that pokes in to?

It doesn't explicitly exist -- it is the flattened list of all columns
from the
left and the right tables.

We were correctly calculating the `relative_offset` -- the offset within the
left- or right-table -- but our `base_offset` was wrong.  Why?

Because in some situations, we don't have the `child_rel_field_offsets`
to pass to the `translate` call for the _join predicates_ and they need
to be there.

So we check if that has been calculated, and if it hasn't, then we
calculate them and pass them in.

Also, I am _sure_ there are edge cases that this doesn't cover, but this is a distinct improvement.