### PR TITLE
fix(projection): Use emit and not project for column selection

### DIFF
--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -476,12 +476,27 @@ def value_op(
     compiler: SubstraitCompiler,
     **kwargs: Any,
 ) -> stalg.Expression:
+    error_args = []
+    # TODO(gforsyth): remove this brittle workaround after extension parsing is ready
+    # TODO(gforsyth): sending in `ERROR` for floating point ops doesn't match
+    # the substrait spec but is what pyarrow currently expects.
+    if (
+        isinstance(op, ops.BinaryOp)
+        and not isinstance(op, ops.Comparison)
+        and isinstance(op.left.type(), (dt.Integer, dt.Floating))
+        and isinstance(op.right.type(), (dt.Integer, dt.Floating))
+    ):
+        error_args.append(
+            stalg.FunctionArgument(enum=stalg.FunctionArgument.Enum(specified="ERROR"))
+        )
+
     # given the details of `op` -> function id
     return stalg.Expression(
         scalar_function=stalg.Expression.ScalarFunction(
             function_reference=compiler.function_id(expr),
             output_type=translate(expr.type()),
-            arguments=[
+            arguments=error_args
+            + [
                 stalg.FunctionArgument(value=translate(arg, compiler, **kwargs))
                 for arg in op.args
                 if isinstance(arg, ir.Expr)

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -127,6 +127,7 @@ def test_translate_table_expansion(compiler):
                     "scalarFunction": {
                         "functionReference": 1,
                         "arguments": [
+                            {"enum": {"specified": "ERROR"}},
                             {
                                 "value": {
                                     "selection": {


### PR DESCRIPTION
I based this off of the output for similar queries generated by `isthmus`, the `substrait-java` implementation.

I need to figure out how to test this for correctness.

Fixes #365 