### PR TITLE
fix(3.x): ignore missing ops when generating inverse mapping

### DIFF
--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -74,7 +74,7 @@ IBIS_SUBSTRAIT_OP_MAPPING = {
 }
 
 SUBSTRAIT_IBIS_OP_MAPPING = {
-    v: getattr(ops, k) for k, v in IBIS_SUBSTRAIT_OP_MAPPING.items()
+    v: getattr(ops, k) for k, v in IBIS_SUBSTRAIT_OP_MAPPING.items() if hasattr(ops, k)
 }
 # override when reversing many-to-one mappings
 SUBSTRAIT_IBIS_OP_MAPPING["extract"] = lambda span, table: getattr(

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -30,6 +30,15 @@ self: super:
     }
   );
 
+  duckdb = super.duckdb.overridePythonAttrs (
+    _: {
+      prePatch = ''
+        substituteInPlace setup.py --replace "multiprocessing.cpu_count()" "int(os.getenv('NIX_BUILD_CORES', multiprocessing.cpu_count()))"
+
+      '';
+    }
+  );
+
   protoletariat = super.protoletariat.overridePythonAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ self.poetry-core ];
   });


### PR DESCRIPTION
For small differences between releases in 3.x, we ignore missing ops when we generate the inverse mapping.  This has no impact on compilation, only on decompilation, which isn't robust anyway.

Fixes #385 