### PR TITLE
feat: add support for ops.Log

### DIFF
--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -32,6 +32,7 @@ IBIS_SUBSTRAIT_OP_MAPPING = {
     "Less": "lt",
     "LessEqual": "lte",
     "Ln": "ln",
+    "Log": "logb",
     "Log2": "log2",
     "Log10": "log10",
     "Lowercase": "lower",


### PR DESCRIPTION
if `base` isn't specified we default to the value of `e`

Resolves #407