### PR TITLE
ci: remove macos poetry job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
         python-version:
           - "3.8"


### PR DESCRIPTION
No reason to run the macos tests twice since we are already running them in the nix job set.