### PR TITLE
feat: adding substrait mappings for ibis approx ops

### DIFF
--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -6,6 +6,8 @@ IBIS_SUBSTRAIT_OP_MAPPING = {
     "Add": "add",
     "And": "and",
     "Any": "any",
+    "ApproxCountDistinct": "approx_count_distinct",
+    "ApproxMedian": "median",
     "Asin": "asin",
     "Atan": "atan",
     "Atan2": "atan2",


### PR DESCRIPTION
Add ibis -> substrait op mappings for approximation ops