### PR TITLE
refactor: clean up output mapping in ops.Selection dispatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,8 @@ filterwarnings = [
   "ignore:`Table.sort_by` is deprecated:FutureWarning",
   # ignore groupby deprecation while we still support 3.x
   "ignore:`Table.groupby` is deprecated:FutureWarning",
+  # ignore sqlalchemy 2.0 warnings (they're upstream in ibis)
+  "ignore: Deprecated API features detected:sqlalchemy.exc.RemovedIn20Warning"
 ]
 markers = ["no_decompile"]
 norecursedirs = ["site-packages", "dist-packages", ".direnv"]


### PR DESCRIPTION
This code was a bit spaghetti and hard to follow, especially with the extra branching for multiple versions of Ibis.  Cleaning it up a little bit to make it easier to follow.