### PR TITLE
feat(round): add ops mapping for `round` scalar func

### DIFF
--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -60,6 +60,7 @@ IBIS_SUBSTRAIT_OP_MAPPING = {
     "RegexReplace": "regexp_replace",
     "Repeat": "repeat",
     "Reverse": "reverse",
+    "Round": "round",
     "RPad": "rpad",
     "RStrip": "rtrim",
     "Sign": "sign",


### PR DESCRIPTION
Resolves #493 

There isn't much to test here, but I can add a specific test for the `round` scalar func extension in #510 once this is merged in.