### PR TITLE
chore(poetry): constrain poetry to fix upstream issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: pip3 install poetry
+      - run: pip3 install 'poetry<1.4'
       - run: poetry install --sync
       - run: poetry run pip install ibis-framework==${{ matrix.ibis-version }}
       - run: poetry run pytest
@@ -152,7 +152,7 @@ jobs:
           python-version: "3.x"
 
       - name: install poetry
-        run: pip3 install poetry
+        run: pip3 install 'poetry<1.4'
 
       - name: verify lockfile
         run: poetry lock --check


### PR DESCRIPTION
I did not think that auto-merge would go through if several CI jobs failed, but you learn something every day.