### PR TITLE
chore(ci): separate ibis jobs, only run on lowest and highest supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           - "38"
           - "39"
           - "310"
+          - "311"
     steps:
       - uses: actions/checkout@v3
 
@@ -80,7 +81,7 @@ jobs:
 
       - name: build package and run tests
         run: nix build --keep-going --print-build-logs --file . --argstr python ${{ matrix.python-version }}
-  poetry:
+  poetry_ibis_3:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -90,11 +91,7 @@ jobs:
           - windows-latest
         python-version:
           - "3.8"
-          - "3.9"
           - "3.10"
-        ibis-version:
-          - "3.2"
-          - "4"
 
     steps:
       - uses: actions/checkout@v3
@@ -105,7 +102,29 @@ jobs:
 
       - run: pip3 install 'poetry<1.4'
       - run: poetry install --sync
-      - run: poetry run pip install ibis-framework==${{ matrix.ibis-version }}
+      - run: poetry run pip install 'ibis-framework==3.2'
+      - run: poetry run pytest
+  poetry_ibis_4:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        python-version:
+          - "3.8"
+          - "3.11"
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: pip3 install 'poetry<1.4'
+      - run: poetry install --sync
+      - run: poetry run pip install 'ibis-framework==4.1'
       - run: poetry run pytest
   dry-run-release:
     runs-on: ubuntu-latest
@@ -161,7 +180,8 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     needs:
       - nix
-      - poetry
+      - poetry_ibis_3
+      - poetry_ibis_4
       - pre-commit
       - dry-run-release
       - check-poetry-lock

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -44,7 +44,7 @@ def test_aggregation_with_sort(t, compiler):
     expr = (
         t.group_by(name_len=lambda t: t.full_name.length())
         .aggregate(max_age=t.age.max(), min_age=t.age.min())
-        .sort_by("ts")
+        .sort_by(t.ts)
         .filter(lambda t: t.name_len > 3)
     )
     result = translate(expr, compiler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,9 @@ filterwarnings = [
   # ignore groupby deprecation while we still support 3.x
   "ignore:`Table.groupby` is deprecated:FutureWarning",
   # ignore sqlalchemy 2.0 warnings (they're upstream in ibis)
-  "ignore: Deprecated API features detected:sqlalchemy.exc.RemovedIn20Warning"
+  "ignore: Deprecated API features detected:sqlalchemy.exc.RemovedIn20Warning",
+  # ignore struct pairs deprecation while we still support 3.x
+  "ignore: `Struct.pairs` is deprecated:FutureWarning"
 ]
 markers = ["no_decompile"]
 norecursedirs = ["site-packages", "dist-packages", ".direnv"]


### PR DESCRIPTION
Separates the Ibis 3.x and Ibis 4.x into separate jobs, because we can't support the same matrix of Python versions in both.

For both 3.x and 4.x, we want to run on the lowest and highest support versions of Python.

For the `nix` job, we run on all supported versions with ibis 4 to generate the files for cachix.