### PR TITLE
feat(udf): add initial support for UDFs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,28 @@ jobs:
       - run: poetry install --sync
       - run: poetry run pip install 'ibis-framework==4.1'
       - run: poetry run pytest
+  poetry_ibis_pyarrow_nightly:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.8"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: pip3 install 'poetry<1.4'
+      - run: poetry install --sync
+      - run: poetry run pip install 'ibis-framework==3.2'
+      - run: poetry run pip install --extra-index-url https://pypi.fury.io/arrow-nightlies --pre pyarrow
+      - run: poetry run pytest
   dry-run-release:
     runs-on: ubuntu-latest
     steps:

--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -1161,7 +1161,9 @@ def _cast(
 ) -> stalg.Expression:
     return stalg.Expression(
         cast=stalg.Expression.Cast(
-            type=translate(op.to), input=translate(op.arg, compiler=compiler, **kwargs)
+            type=translate(op.to),
+            input=translate(op.arg, compiler=compiler, **kwargs),
+            failure_behavior=stalg.Expression.Cast.FAILURE_BEHAVIOR_THROW_EXCEPTION,
         )
     )
 

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -130,6 +130,7 @@ def test_translate_table_expansion(compiler):
                             {
                                 "value": {
                                     "cast": {
+                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION",
                                         "input": {
                                             "selection": {
                                                 "directReference": {"structField": {}},
@@ -223,6 +224,7 @@ def test_emit_mutate_select_all(compiler):
                             {
                                 "value": {
                                     "cast": {
+                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION",
                                         "input": {"literal": {"i8": 1}},
                                         "type": {
                                             "i64": {

--- a/ibis_substrait/tests/compiler/test_extensions.py
+++ b/ibis_substrait/tests/compiler/test_extensions.py
@@ -2,9 +2,7 @@ import operator
 
 import ibis
 import ibis.expr.operations as ops
-import pyarrow as pa
 import pytest
-from packaging.version import parse as vparse
 
 DEFAULT_PREFIX = "https://github.com/substrait-io/substrait/blob/main/extensions"
 

--- a/ibis_substrait/tests/integration/test_pyarrow.py
+++ b/ibis_substrait/tests/integration/test_pyarrow.py
@@ -1,0 +1,160 @@
+import ibis
+import pytest
+from ibis.udf.vectorized import elementwise
+from packaging.version import parse as vparse
+
+from ibis_substrait.compiler.core import SubstraitCompiler
+
+pa = pytest.importorskip("pyarrow")
+pc = pytest.importorskip("pyarrow.compute")
+substrait = pytest.importorskip("pyarrow.substrait")
+
+
+arrow12 = pytest.mark.skipif(
+    vparse(pa.__version__) <= vparse("11.0.0"),
+    reason="UDF support added in Arrow 12",
+)
+
+
+def get_table_provider(tbl):
+    """Create a table_provider that always returns tbl"""
+
+    def table_provider(names, schema):
+        return tbl
+
+    return table_provider
+
+
+def to_ibis_table(arrow_table, table_name="t1"):
+    """Create ibis Table from pyarrow Table"""
+    # TODO: use ibis.backends.pyarrow.datatypes.from_pyarrow_schema once we drop ibis 3.x
+    return ibis.table(
+        zip(arrow_table.schema.names, [str(type) for type in arrow_table.schema.types]),
+        name=table_name,
+    )
+
+
+def run_query(plan, tbl):
+    query_bytes = plan.SerializeToString()
+    result = substrait.run_query(
+        pa.py_buffer(query_bytes), table_provider=get_table_provider(tbl)
+    )
+
+    results = result.read_all()
+    assert type(results) == pa.lib.Table
+
+    return results
+
+
+@pytest.fixture
+def arrow_table():
+    return pa.Table.from_pydict(
+        {
+            "a": [1, 2, 3],
+            "b": [3.4, 3.7, 2.0],
+            "c": ["x", "y", "z"],
+            "d": [True, False, True],
+        }
+    )
+
+
+@arrow12
+def test_pyarrow_produces_correct_result(compiler, arrow_table):
+    ibis_table = to_ibis_table(arrow_table)
+    query = ibis_table  # identity
+    plan = compiler.compile(query)
+    result = run_query(plan, arrow_table)
+
+    assert result == arrow_table
+
+
+@arrow12
+def test_pyarrow_can_consume_basic_operations(compiler, arrow_table):
+    t = to_ibis_table(arrow_table)
+
+    # identity
+    query = t
+    plan = compiler.compile(query)
+    result = run_query(plan, arrow_table)
+    assert result == arrow_table
+
+    # mutate, re-use column
+    query = t.mutate(a=t.a * 2)
+    plan = compiler.compile(query)
+    result = run_query(plan, arrow_table)
+
+    assert set(result.column_names) == set(arrow_table.column_names)
+
+    # mutate, add new derived column
+    query = t.mutate(e=t.b + 1)
+    plan = compiler.compile(query)
+    result = run_query(plan, arrow_table)
+
+    assert set(result.column_names) == {*arrow_table.column_names, "e"}
+
+
+@arrow12
+def test_extension_udf():
+    def register_pyarrow_udf(udf, registry=None):
+        import inspect
+
+        from ibis.backends.pyarrow.datatypes import to_pyarrow_type
+
+        if registry is None:
+            registry = pc.function_registry()
+
+        def wrapper(ctx, *args):
+            out = udf.func(*args, ctx=ctx)
+            return out
+
+        in_types = dict(
+            zip(
+                inspect.getfullargspec(udf.func).args,
+                map(to_pyarrow_type, udf.input_type),
+            )
+        )
+        out_type = to_pyarrow_type(udf.output_type)
+
+        if udf.func.__name__ not in set(registry.list_functions()):
+            pc.register_scalar_function(
+                wrapper,
+                udf.func.__name__,
+                {
+                    "summary": f"UDF {udf.func.__name__} defined in Ibis",
+                    "description": "",
+                },
+                in_types,
+                out_type,
+            )
+
+    @elementwise(input_type=["int64"], output_type="int64")
+    def add1(col: pa.Int64Scalar, ctx=None) -> pa.Int64Scalar:
+        return pc.call_function("add", [col, 1], memory_pool=ctx.memory_pool)
+
+    @elementwise(input_type=["int64"], output_type="int64")
+    def sub1(col: pa.Int64Scalar, ctx=None) -> pa.Int64Scalar:
+        return pc.call_function("subtract", [col, 1], memory_pool=ctx.memory_pool)
+
+    registry = pc.function_registry()
+    register_pyarrow_udf(add1, registry)
+    register_pyarrow_udf(sub1, registry)
+
+    t = ibis.table([("a", "int")], name="t")
+    query = t.mutate(b=add1(t.a), c=sub1(t.a))
+
+    compiler = SubstraitCompiler(
+        udf_uri="urn:arrow:substrait_simple_extension_function"
+    )
+
+    plan = compiler.compile(query)
+
+    arrow_table = pa.Table.from_pydict(
+        {
+            "a": [1, 2, 3],
+        }
+    )
+
+    result = run_query(plan, arrow_table)
+
+    assert result[1].to_pylist() == [2, 3, 4]
+    assert result[2].to_pylist() == [0, 1, 2]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1050,6 +1050,44 @@ files = [
 tests = ["pytest"]
 
 [[package]]
+name = "pyarrow"
+version = "11.0.0"
+description = "Python library for Apache Arrow"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyarrow-11.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:40bb42afa1053c35c749befbe72f6429b7b5f45710e85059cdd534553ebcf4f2"},
+    {file = "pyarrow-11.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7c28b5f248e08dea3b3e0c828b91945f431f4202f1a9fe84d1012a761324e1ba"},
+    {file = "pyarrow-11.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a37bc81f6c9435da3c9c1e767324ac3064ffbe110c4e460660c43e144be4ed85"},
+    {file = "pyarrow-11.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad7c53def8dbbc810282ad308cc46a523ec81e653e60a91c609c2233ae407689"},
+    {file = "pyarrow-11.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:25aa11c443b934078bfd60ed63e4e2d42461682b5ac10f67275ea21e60e6042c"},
+    {file = "pyarrow-11.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:e217d001e6389b20a6759392a5ec49d670757af80101ee6b5f2c8ff0172e02ca"},
+    {file = "pyarrow-11.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ad42bb24fc44c48f74f0d8c72a9af16ba9a01a2ccda5739a517aa860fa7e3d56"},
+    {file = "pyarrow-11.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d942c690ff24a08b07cb3df818f542a90e4d359381fbff71b8f2aea5bf58841"},
+    {file = "pyarrow-11.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f010ce497ca1b0f17a8243df3048055c0d18dcadbcc70895d5baf8921f753de5"},
+    {file = "pyarrow-11.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:2f51dc7ca940fdf17893227edb46b6784d37522ce08d21afc56466898cb213b2"},
+    {file = "pyarrow-11.0.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:1cbcfcbb0e74b4d94f0b7dde447b835a01bc1d16510edb8bb7d6224b9bf5bafc"},
+    {file = "pyarrow-11.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaee8f79d2a120bf3e032d6d64ad20b3af6f56241b0ffc38d201aebfee879d00"},
+    {file = "pyarrow-11.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:410624da0708c37e6a27eba321a72f29d277091c8f8d23f72c92bada4092eb5e"},
+    {file = "pyarrow-11.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2d53ba72917fdb71e3584ffc23ee4fcc487218f8ff29dd6df3a34c5c48fe8c06"},
+    {file = "pyarrow-11.0.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f12932e5a6feb5c58192209af1d2607d488cb1d404fbc038ac12ada60327fa34"},
+    {file = "pyarrow-11.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:41a1451dd895c0b2964b83d91019e46f15b5564c7ecd5dcb812dadd3f05acc97"},
+    {file = "pyarrow-11.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:becc2344be80e5dce4e1b80b7c650d2fc2061b9eb339045035a1baa34d5b8f1c"},
+    {file = "pyarrow-11.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f40be0d7381112a398b93c45a7e69f60261e7b0269cc324e9f739ce272f4f70"},
+    {file = "pyarrow-11.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:362a7c881b32dc6b0eccf83411a97acba2774c10edcec715ccaab5ebf3bb0835"},
+    {file = "pyarrow-11.0.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:ccbf29a0dadfcdd97632b4f7cca20a966bb552853ba254e874c66934931b9841"},
+    {file = "pyarrow-11.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e99be85973592051e46412accea31828da324531a060bd4585046a74ba45854"},
+    {file = "pyarrow-11.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69309be84dcc36422574d19c7d3a30a7ea43804f12552356d1ab2a82a713c418"},
+    {file = "pyarrow-11.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da93340fbf6f4e2a62815064383605b7ffa3e9eeb320ec839995b1660d69f89b"},
+    {file = "pyarrow-11.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:caad867121f182d0d3e1a0d36f197df604655d0b466f1bc9bafa903aa95083e4"},
+    {file = "pyarrow-11.0.0.tar.gz", hash = "sha256:5461c57dbdb211a632a48facb9b39bbeb8a7905ec95d768078525283caef5f6d"},
+]
+
+[package.dependencies]
+numpy = ">=1.16.6"
+
+[[package]]
 name = "pycodestyle"
 version = "2.10.0"
 description = "Python style guide checker"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1666,4 +1666,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4"
-content-hash = "6149106cbacd15b6e2746b6c34361de494b9ed1b2a4c2ab93eef55851daa181e"
+content-hash = "8d6c1d08e76623efbf5a04f0eba40402ffdaf0942c27479191c6d384b17eb8ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ pytz = "^2022.1"
 substrait-validator = "^0.0.11"
 packaging = "^23.0"
 pathspec = "0.11.0"
+pyarrow = "^11.0.0"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
What does this do?
Adds a dispatch rule for the `ElementWiseVectorizedUDF` op.

This dispatch does the following:
- Uses the ibis type annotations from the UDF decorator to set the expected input and output types of the scalar function.
- sets the URI for this extension (since it is an extension) to the value of the `udf_uri` attribute of the `SubstraitCompiler`.  This should be set at instantiation time.  If there is no available `udf_uri` on the compiler it will error out.
- Returns the substrait scalar function call 

This assumes that you have some other means of registering the UDFs with your execution engine -- there's an example of what that might look like in `ibis_substrait/tests/integrations/tests/test_pyarrow.py`
