### PR TITLE
fix: Fix emit output of projection node to be based off input table i…

### DIFF
--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -822,6 +822,12 @@ def selection(
             elif output_mapping := rel.common.emit.output_mapping:
                 mapping_counter = itertools.count(len(output_mapping))
                 break
+            elif not isinstance(op.table.op(), ops.Join):
+                # If child table is join, we cannot reliably call schema due to
+                # potentially duplicate column names, so fallback to the orignal
+                # logic.
+                mapping_counter = itertools.count(len(op.table.op().schema))
+                break
         else:
             source_tables = _find_parent_tables(op)
             mapping_counter = itertools.count(sum(len(t.schema) for t in source_tables))


### PR DESCRIPTION
…nstead of source tables

I found an issue with projection emit outputting when doing a "asof_join -> filter -> projection"

My code looks like
```
t = t1.asof_join(t2, ...) 
t = t[t[col] > 0]
t = t.muate(y=t[x] * 2)
```

Without the patch the plan looks like
```
relations {
  root {
    input {
      project {
        common {
          emit {
            output_mapping: 8
            output_mapping: 9
            output_mapping: 10
            output_mapping: 11
            output_mapping: 12
            output_mapping: 13
            output_mapping: 14
          }
        }
        input {
          filter {
            input {
              filter {
                input {
                  filter {
                    input {
                      extension_multi {
                        common {
                          emit {
                            output_mapping: 0
                            output_mapping: 1
                            output_mapping: 2
                            output_mapping: 3
                            output_mapping: 6
                            output_mapping: 7
                          }
                        }
...
```
This is problematic because the output of `asof_join` has 6 columns, not 8

This is I think how the plan should look like:
```
relations {
  root {
    input {
      project {
        common {
          emit {
            output_mapping: 6
            output_mapping: 7
            output_mapping: 8
            output_mapping: 9
            output_mapping: 10
            output_mapping: 11
            output_mapping: 12
          }
        }
        input {
          filter {
            input {
              filter {
                input {
                  filter {
                    input {
                      extension_multi {
                        common {
                          emit {
                            output_mapping: 0
                            output_mapping: 1
                            output_mapping: 2
                            output_mapping: 3
                            output_mapping: 6
                            output_mapping: 7
                          }
                        }
```

Edit:
I think the issue is not only related to asof join - even with aggregation I think it might be problematic, e.g

source [0, 1, 2, 3, 4, 5]
-> aggregation (let's say group by a column with two metrics) [0, 1, 2]
-> filter
-> projection

when computing the emit output from the last projection, with the logic before the PR, since the parent rel of projection is not aggregation or does it have an emit output, it will use the "else" logic which compute from the source, and the emit output for the last projection would start from 6, where it should start from 3. Basically as long as there is any rel between the projection and source that would reduce the number of columns this would not work I believe.