### PR TITLE
refactor: remove expr arguments in translate

### DIFF
--- a/ibis_substrait/compiler/core.py
+++ b/ibis_substrait/compiler/core.py
@@ -57,18 +57,14 @@ class SubstraitCompiler:
 
     def function_id(
         self,
-        *,
-        expr: ir.ValueExpr | None = None,
-        op: ops.Value | None = None,
+        op: ops.Value,
     ) -> int:
         """Create a function mapping for a given expression.
 
         Parameters
         ----------
-        expr
-            An ibis expression that produces a value.
         op
-            Passthrough op to directly specify desired substrait scalar function
+            Ibis operation to use to lookup desired substrait scalar function
 
         Returns
         -------
@@ -76,8 +72,6 @@ class SubstraitCompiler:
             This is a unique identifier for a given operation type, *argument
             types N-tuple.
         """
-        if op is None:
-            op = expr.op() if expr is not None else None
         op_type = type(op)
         op_name = IBIS_SUBSTRAIT_OP_MAPPING[op_type.__name__]
 
@@ -196,7 +190,7 @@ class SubstraitCompiler:
         expr_schema = expr.schema()
         rel = stp.PlanRel(
             root=stalg.RelRoot(
-                input=translate(expr.op(), expr=expr, compiler=self, **kwargs),
+                input=translate(expr.op(), compiler=self, **kwargs),
                 names=translate(expr_schema).names,
             )
         )

--- a/ibis_substrait/tests/compiler/test_literal.py
+++ b/ibis_substrait/tests/compiler/test_literal.py
@@ -300,7 +300,7 @@ literal_cases = pytest.mark.parametrize(
 
 @literal_cases
 def test_literal(compiler, expr, ir):
-    result = translate(expr, compiler)
+    result = translate(expr, compiler=compiler)
     assert result.SerializeToString() == ir.SerializeToString()
 
 
@@ -319,14 +319,14 @@ def test_decimal_literal(compiler):
             )
         )
     )
-    result = translate(expr, compiler)
+    result = translate(expr, compiler=compiler)
     assert result.SerializeToString() == ir.SerializeToString()
 
 
 @pytest.mark.parametrize("value", [ibis.NA, ibis.literal(None)])
 def test_bare_null(compiler, value):
     with pytest.raises(NotImplementedError, match="untyped null literals"):
-        translate(value, compiler)
+        translate(value, compiler=compiler)
 
 
 @literal_cases


### PR DESCRIPTION
This removes all usage of `expr` being passed explicitly to mapping
functions.  There are a few cases where Ibis 3.x will pass in
expressions still, but those should be handled by the `_expr` rule,
which forwards on the `op` (at a cost of an extra dispatch).

There are also a few bits where we do reductions on predicates that
operate on expressions.  Those should be converted to ops where
possible (without breaking support for older Ibis versions).