### PR TITLE
fix(window functions): handle window function ranges correctly

### DIFF
--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -480,7 +480,7 @@ def _translate_window_bounds(
     following = [None] if follows is None else following
 
     if len(preceding) == 2:
-        if following:
+        if following and following != [None]:
             raise ValueError(
                 "`following` not allowed when window bounds are both preceding"
             )
@@ -492,7 +492,7 @@ def _translate_window_bounds(
         raise ValueError(f"preceding must be length 1 or 2 got: {len(preceding)}")
 
     if len(following) == 2:
-        if preceding:
+        if preceding and preceding != [None]:
             raise ValueError(
                 "`preceding` not allowed when window bounds are both following"
             )

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -60,8 +60,23 @@ def test_aggregation_no_args(t, compiler):
     assert js
 
 
-def test_aggregation_window(t, compiler):
-    expr = t.projection([t.full_name.length().mean().over(ibis.window(group_by="age"))])
+@pytest.mark.parametrize(
+    "preceding, following",
+    [
+        ((4, 2), None),
+        (None, (1, 5)),
+        (None, None),
+        (2, 4),
+    ],
+)
+def test_aggregation_window(t, compiler, preceding, following):
+    expr = t.projection(
+        [
+            t.full_name.length()
+            .mean()
+            .over(ibis.window(preceding=preceding, following=following, group_by="age"))
+        ]
+    )
     result = translate(expr, compiler)
     js = to_dict(result)
     assert js


### PR DESCRIPTION
The test suite was only testing window functions that were windowed over
an entire group.  I added some more restrictive bounds and also fixed a
check that was a bit over-aggressive in erroring.