### PR TITLE
chore(nix): remove mac nix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
           - "39"
           - "310"
           - "311"
-        include:
-         - os: macos-latest
-           python-version: "310"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
These are failing due to SIP chicanery and it isn't worth the overhead to debug.