### PR TITLE
refactor: drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - "38"
           - "39"
           - "310"
           - "311"
@@ -90,16 +89,16 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - "3.8"
-          - "3.10"
+          - "3.9"
+          - "3.11"
         ibis-version:
           - "3.2"
           - "4.1"
           - "5.1"
         include:
          - os: windows-latest
-           python-version: "3.10"
-           ibis-version: "4.1"
+           python-version: "3.11"
+           ibis-version: "5.1"
 
 
     steps:
@@ -130,11 +129,12 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - "3.8"
-          - "3.10"
+          - "3.9"
+          - "3.11"
         ibis-version:
           - "3.2"
           - "4.1"
+          - "5.1"
 
     steps:
       - uses: actions/checkout@v3

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
     in
     rec {
       packages = {
-        inherit (pkgs) ibisSubstrait38 ibisSubstrait39 ibisSubstrait310 ibisSubstrait311;
+        inherit (pkgs) ibisSubstrait39 ibisSubstrait310 ibisSubstrait311;
 
         default = pkgs.ibisSubstrait311;
       };
@@ -90,7 +90,6 @@
       nixpkgs = pkgs;
 
       devShells = rec {
-        ibisSubstrait38 = mkDevShell pkgs.ibisSubstraitDevEnv38;
         ibisSubstrait39 = mkDevShell pkgs.ibisSubstraitDevEnv39;
         ibisSubstrait310 = mkDevShell pkgs.ibisSubstraitDevEnv310;
         ibisSubstrait311 = mkDevShell pkgs.ibisSubstraitDevEnv311;

--- a/ibis_substrait/compiler/core.py
+++ b/ibis_substrait/compiler/core.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any, Hashable, Iterator
+from collections.abc import Hashable, Iterator
+from typing import TYPE_CHECKING, Any
 
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops

--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import importlib.resources
 from collections import defaultdict
+from collections.abc import Iterator, Mapping
 from pathlib import Path
-from typing import Any, Iterator, Mapping
+from typing import Any
 
 import ibis.expr.operations as ops
 import yaml
@@ -215,24 +216,10 @@ def register_extension_yaml(
 
 
 def _populate_default_extensions() -> None:
-    # TODO: we should load all the yaml files and not maintain this list
-    EXTENSION_YAMLS = [
-        "functions_aggregate_approx.yaml",
-        "functions_aggregate_generic.yaml",
-        "functions_arithmetic.yaml",
-        "functions_arithmetic_decimal.yaml",
-        "functions_boolean.yaml",
-        "functions_comparison.yaml",
-        "functions_datetime.yaml",
-        "functions_logarithmic.yaml",
-        "functions_rounding.yaml",
-        "functions_set.yaml",
-        "functions_string.yaml",
-    ]
-
-    for yaml_file in EXTENSION_YAMLS:
-        with importlib.resources.path("substrait.extensions", yaml_file) as fpath:
-            register_extension_yaml(fpath)
+    for fpath in importlib.resources.files("substrait.extensions").glob(  # type: ignore
+        "functions*.yaml"
+    ):
+        register_extension_yaml(fpath)
 
 
 _populate_default_extensions()

--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -14,7 +14,8 @@ import itertools
 import math
 import operator
 import uuid
-from typing import Any, Iterable, Mapping, MutableMapping, Sequence, TypeVar, Union
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from typing import Any, TypeVar, Union
 
 import ibis
 import ibis.expr.datatypes as dt

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -39,12 +39,10 @@ let
     final.callPackage drv { inherit python; };
 in
 {
-  ibisSubstraitDevEnv38 = mkPoetryEnv final.python38;
   ibisSubstraitDevEnv39 = mkPoetryEnv final.python39;
   ibisSubstraitDevEnv310 = mkPoetryEnv final.python310;
   ibisSubstraitDevEnv311 = mkPoetryEnv final.python311;
 
-  ibisSubstrait38 = mkIbisSubstrait final.python38;
   ibisSubstrait39 = mkIbisSubstrait final.python39;
   ibisSubstrait310 = mkIbisSubstrait final.python310;
   ibisSubstrait311 = mkIbisSubstrait final.python311;

--- a/poetry.lock
+++ b/poetry.lock
@@ -1226,7 +1226,6 @@ files = [
 [package.dependencies]
 markdown-it-py = ">=2.1.0,<3.0.0"
 pygments = ">=2.6.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
@@ -1534,5 +1533,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.1,<4"
-content-hash = "6ca98d8ae10e0c3871cb0840bff12289ef3c8d32d04ac26e0a313036977f3086"
+python-versions = ">=3.9,<4"
+content-hash = "cdf62466879cff2b8aedf559248fcc23c71acdc77ba259f83ad96fb24aebfd11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4"
+python = ">=3.9,<4"
 ibis-framework = ">=3"
 packaging = ">=21.3"
 pyyaml = ">=5"
@@ -109,10 +109,9 @@ ignore = [
   "SIM114", # combine `if` branches
   "SIM117", # nested withs
   "SIM118", # remove .keys() calls from dictionaries
-  # TODO(gil): re-enable after we drop 3.8
   "UP006", # use collections.deque instead of Deque for type annotation
 ]
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.per-file-ignores]
 "*test*.py" = ["D"] # ignore all docstring lints in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,9 +142,6 @@ filterwarnings = [
   "ignore: Deprecated API features detected:sqlalchemy.exc.RemovedIn20Warning",
   # ignore struct pairs deprecation while we still support 3.x
   "ignore: `Struct.pairs` is deprecated:FutureWarning",
-  # ignore importlib.resources.path deprecation while 3.8 is still supported
-  # we'll drop 3.8 before we add support for 3.12, then we can handle this
-  "ignore: path is deprecated:DeprecationWarning"
 ]
 markers = ["no_decompile"]
 norecursedirs = ["site-packages", "dist-packages", ".direnv"]


### PR DESCRIPTION
In accordance with NEP-29 https://numpy.org/neps/nep-0029-deprecation_policy.html