### PR TITLE
feat: add type signature to scalar function name definitions

### DIFF
--- a/ibis_substrait/compiler/core.py
+++ b/ibis_substrait/compiler/core.py
@@ -97,6 +97,7 @@ class SubstraitCompiler:
             )
 
         anykey = ("any",) * len([arg for arg in op.args if arg is not None])
+        sigkey = anykey
 
         # First check if `any` is an option
         # This function will take arguments of any type
@@ -136,7 +137,12 @@ class SubstraitCompiler:
 
         extension_uri = self.register_extension_uri(function_extension.uri)
 
-        extension_function = self.create_extension_function(extension_uri, op_name)
+        # format signature key for extension name
+        extension_type_signature = "_".join(sigkey)
+
+        extension_function = self.create_extension_function(
+            extension_uri, f"{op_name}:{extension_type_signature}"
+        )
 
         return extension_function
 

--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -111,28 +111,28 @@ IBIS_SUBSTRAIT_TYPE_MAPPING = {
     "Int64": "i64",
     "Float32": "fp32",
     "Float64": "fp64",
-    "String": "varchar",
-    "string": "string",
-    "Boolean": "boolean",
+    "String": "str",
+    "string": "str",
+    "Boolean": "bool",
     "Date": "date",
-    "Decimal": "decimal",
+    "Decimal": "dec",
 }
 
 _normalized_key_names = {
     # decimal precision and scale aren't part of the
     # extension signature they're passed in separately
-    "decimal<p, s>": "decimal",
-    "decimal<p,s>": "decimal",
-    "decimal<p1,s1>": "decimal",
-    "decimal<p2,s2>": "decimal",
+    "decimal<p, s>": "dec",
+    "decimal<p,s>": "dec",
+    "decimal<p1,s1>": "dec",
+    "decimal<p2,s2>": "dec",
     # we don't care about string length
-    "fixedchar<l1>": "fixedchar",
-    "fixedchar<l2>": "fixedchar",
-    "varchar<l1>": "varchar",
-    "varchar<l2>": "varchar",
-    "varchar<l3>": "varchar",
+    "fixedchar<l1>": "str",
+    "fixedchar<l2>": "str",
+    "varchar<l1>": "str",
+    "varchar<l2>": "str",
+    "varchar<l3>": "str",
     # for now ignore nullability marker
-    "boolean?": "boolean",
+    "boolean?": "bool",
     # why is there a 1?
     "any1": "any",
     "Date": "date",

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
@@ -18,49 +18,49 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "lte"
+        "name": "lte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "sum"
+        "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 3,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 4,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 5,
-        "name": "add"
+        "name": "add:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 6,
-        "name": "avg"
+        "name": "avg:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 7,
-        "name": "count"
+        "name": "count:any"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
@@ -18,49 +18,49 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 3,
-        "name": "lt"
+        "name": "lt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 4,
-        "name": "gt"
+        "name": "gt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 5,
-        "name": "sum"
+        "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 6,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 7,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
@@ -18,35 +18,35 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 3,
-        "name": "lt"
+        "name": "lt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 4,
-        "name": "gte"
+        "name": "gte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 5,
-        "name": "count"
+        "name": "count:any"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
@@ -18,49 +18,49 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 3,
-        "name": "gte"
+        "name": "gte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 4,
-        "name": "lt"
+        "name": "lt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 5,
-        "name": "sum"
+        "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 6,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 7,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
@@ -18,42 +18,42 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "gte"
+        "name": "gte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 3,
-        "name": "lt"
+        "name": "lt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 4,
-        "name": "between"
+        "name": "between:any_any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 5,
-        "name": "sum"
+        "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 6,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
@@ -22,56 +22,56 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "extract"
+        "name": "extract:date"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 3,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 4,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 5,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 6,
-        "name": "or"
+        "name": "or:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 7,
-        "name": "between"
+        "name": "between:any_any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 8,
-        "name": "sum"
+        "name": "sum:dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h090/tpc_h090.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h090/tpc_h090.json
@@ -26,49 +26,49 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 3,
-        "name": "like"
+        "name": "like:str_str"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 4,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 5,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 5,
         "functionAnchor": 6,
-        "name": "extract"
+        "name": "extract:date"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 7,
-        "name": "sum"
+        "name": "sum:dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h091/tpc_h091.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h091/tpc_h091.json
@@ -26,49 +26,49 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 3,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 4,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 5,
-        "name": "extract"
+        "name": "extract:date"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 5,
         "functionAnchor": 6,
-        "name": "like"
+        "name": "like:str_str"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 7,
-        "name": "sum"
+        "name": "sum:dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
@@ -18,49 +18,49 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 3,
-        "name": "gte"
+        "name": "gte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 4,
-        "name": "lt"
+        "name": "lt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 5,
-        "name": "sum"
+        "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 6,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 7,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
@@ -14,28 +14,28 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "sum"
+        "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 3,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 4,
-        "name": "gt"
+        "name": "gt:any_any"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
@@ -18,35 +18,35 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 3,
-        "name": "lt"
+        "name": "lt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 4,
-        "name": "gte"
+        "name": "gte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 5,
-        "name": "sum"
+        "name": "sum:i8"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
@@ -22,35 +22,35 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 3,
-        "name": "not"
+        "name": "not:bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 4,
-        "name": "like"
+        "name": "like:str_str"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 5,
-        "name": "count"
+        "name": "count:any"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
@@ -14,14 +14,14 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "sum"
+        "name": "sum:dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
@@ -18,63 +18,63 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "or"
+        "name": "or:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 3,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 4,
-        "name": "gte"
+        "name": "gte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 5,
-        "name": "lte"
+        "name": "lte:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 6,
-        "name": "between"
+        "name": "between:any_any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 7,
-        "name": "sum"
+        "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 8,
-        "name": "multiply"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 9,
-        "name": "subtract"
+        "name": "subtract:dec_dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
@@ -14,14 +14,14 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
@@ -18,42 +18,42 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 3,
-        "name": "gt"
+        "name": "gt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 4,
-        "name": "not_equal"
+        "name": "not_equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 5,
-        "name": "not"
+        "name": "not:bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 6,
-        "name": "count"
+        "name": "count:any"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
@@ -26,49 +26,49 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and"
+        "name": "and:bool_bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "substring"
+        "name": "substring:str_i32_i32"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 3,
-        "name": "gt"
+        "name": "gt:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 4,
-        "name": "equal"
+        "name": "equal:any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 5,
-        "name": "not"
+        "name": "not:bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 6,
-        "name": "count"
+        "name": "count:any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 5,
         "functionAnchor": 7,
-        "name": "sum"
+        "name": "sum:dec"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/test_extensions.py
+++ b/ibis_substrait/tests/compiler/test_extensions.py
@@ -28,8 +28,8 @@ def test_extension_substring(compiler, two, three):
 
     uris = [ext.uri for ext in plan.extension_uris]
 
-    assert "equal" in scalar_func_names
-    assert "substring" in scalar_func_names
+    assert "equal:any_any" in scalar_func_names
+    assert "substring:str_i32_i32" in scalar_func_names
 
     assert f"{DEFAULT_PREFIX}/functions_comparison.yaml" in uris
     assert f"{DEFAULT_PREFIX}/functions_string.yaml" in uris
@@ -38,12 +38,12 @@ def test_extension_substring(compiler, two, three):
 @pytest.mark.parametrize(
     "left, right, bin_op, exp_func",
     [
-        ("int32", "int32", operator.gt, "gt"),
-        ("int32", "int64", operator.lt, "lt"),
-        ("int16", "int8", operator.ge, "gte"),
-        ("float64", "int8", operator.le, "lte"),
-        ("float64", "float32", operator.eq, "equal"),
-        ("int8", "float64", operator.ne, "not_equal"),
+        ("int32", "int32", operator.gt, "gt:any_any"),
+        ("int32", "int64", operator.lt, "lt:any_any"),
+        ("int16", "int8", operator.ge, "gte:any_any"),
+        ("float64", "int8", operator.le, "lte:any_any"),
+        ("float64", "float32", operator.eq, "equal:any_any"),
+        ("int8", "float64", operator.ne, "not_equal:any_any"),
     ],
 )
 def test_extension_binop_comparison(compiler, left, right, bin_op, exp_func):
@@ -84,7 +84,7 @@ def test_extension_unaryop_comparison(compiler, left, unary_op, exp_func):
 
     uris = [ext.uri for ext in plan.extension_uris]
 
-    assert exp_func in scalar_func_names
+    assert any(exp_func in func_name for func_name in scalar_func_names)
 
     assert f"{DEFAULT_PREFIX}/functions_comparison.yaml" in uris
 
@@ -96,112 +96,127 @@ def test_extension_unaryop_comparison(compiler, left, unary_op, exp_func):
             "decimal(15, 3)",
             "decimal(15, 3)",
             operator.add,
-            "add",
+            "add:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "decimal(15, 3)",
             "decimal(15, 3)",
             operator.sub,
-            "subtract",
+            "subtract:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "decimal(15, 3)",
             "decimal(15, 3)",
             operator.mul,
-            "multiply",
+            "multiply:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "decimal(15, 3)",
             "decimal(15, 3)",
             operator.truediv,
-            "divide",
+            "divide:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "decimal(15, 3)",
             "int",
             operator.add,
-            "add",
+            # should promote to dec_dec from dec_int
+            "add:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "float64",
             "decimal(15, 3)",
             operator.sub,
-            "subtract",
+            # should promote to dec_dec from fp32_dec
+            "subtract:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "decimal(15, 3)",
             "int32",
             operator.mul,
-            "multiply",
+            # should promote to dec_dec from dec_int
+            "multiply:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "float32",
             "decimal(15, 3)",
             operator.truediv,
-            "divide",
+            # should promote to dec_dec from fp32_dec
+            "divide:dec_dec",
             f"{DEFAULT_PREFIX}/functions_arithmetic_decimal.yaml",
         ),
         (
             "int",
             "int8",
             operator.add,
-            "add",
+            # int is shorthand for i64, should promote to i64_i64
+            "add:i64_i64",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
         (
             "int32",
             "int",
             operator.sub,
-            "subtract",
+            # int is shorthand for i64, should promote to i64_i64
+            "subtract:i64_i64",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
         (
             "int64",
             "int",
             operator.mul,
-            "multiply",
+            # int is shorthand for i64, should promote to i64_i64
+            "multiply:i64_i64",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
         (
             "int",
             "int",
             operator.truediv,
-            "divide",
+            "divide:i64_i64",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
         (
             "float64",
             "float",
             operator.add,
-            "add",
+            "add:fp64_fp64",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
         (
             "float",
             "float32",
             operator.sub,
-            "subtract",
+            # float is shorthand for fp64, should promote to fp64_fp64
+            "subtract:fp64_fp64",
+            f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
+        ),
+        (
+            "float32",
+            "float32",
+            operator.sub,
+            "subtract:fp32_fp32",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
         (
             "float64",
             "float64",
             operator.mul,
-            "multiply",
+            "multiply:fp64_fp64",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
         (
             "float",
             "float",
             operator.truediv,
-            "divide",
+            "divide:fp64_fp64",
             f"{DEFAULT_PREFIX}/functions_arithmetic.yaml",
         ),
     ],
@@ -230,14 +245,14 @@ def test_extension_arithmetic(compiler, left, right, bin_op, exp_func, exp_uri):
             "bool",
             "bool",
             operator.and_,
-            "and",
+            "and:bool_bool",
             f"{DEFAULT_PREFIX}/functions_boolean.yaml",
         ),
         (
             "bool",
             "bool",
             operator.or_,
-            "or",
+            "or:bool_bool",
             f"{DEFAULT_PREFIX}/functions_boolean.yaml",
         ),
     ],


### PR DESCRIPTION
As per a recent change in the spec upstream (and also to enable better
compatibility with other substrait libraries), extension function names
now have the expected input types included in the name of the function.

This can seem very weird, but helps to make it much easier for consumers
to parse a plan.

Basically, if you call a scalar function `add` and pass in two integer
32s, the "name" of the function will be `add:i32_i32`.

We do not validate that the particular signature exists in the
extension.yaml files, but we do perform the requisite upcasting to make
sure that only integers and floats of the same precision are passed to
functions (also in line with the Substrait specification).

Resolves #703