### PR TITLE
fix(extensions): use compound signature when creating new URI

### DIFF
--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
@@ -25,7 +25,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
@@ -18,7 +18,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
@@ -25,7 +25,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
@@ -18,7 +18,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
@@ -50,14 +50,14 @@
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 5,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
         "functionAnchor": 6,
-        "name": "or:bool_bool"
+        "name": "or:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h090/tpc_h090.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h090/tpc_h090.json
@@ -33,7 +33,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h091/tpc_h091.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h091/tpc_h091.json
@@ -33,7 +33,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
@@ -25,7 +25,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
@@ -25,7 +25,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
@@ -22,7 +22,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
@@ -25,14 +25,14 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "or:bool_bool"
+        "name": "or:bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 3,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
@@ -21,7 +21,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     }
   ],

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
@@ -25,7 +25,7 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
@@ -26,7 +26,7 @@
       "extensionFunction": {
         "extensionUriReference": 1,
         "functionAnchor": 1,
-        "name": "and:bool_bool"
+        "name": "and:bool"
       }
     },
     {


### PR DESCRIPTION
This fixes a bug that I missed when I reintroduced the compound function
signatures.

If we call `add` using int32 and float32, respectively, then we should
have two separate scalar function anchors, one that is `add:i32_i32` and
another that is `add:fp32_fp32`.  This is now handled correctly.

There is a bit of uncertainty about how we handle the signatures for
variadic functions, especially ones that accept (optionally) zero
arguments.

What I have here is my best guess as to the right way to do it, and I
can update it after consulting with the Substrait community at the next meeting.