### PR TITLE
fix: check for function impls before trying to parse

### DIFF
--- a/ibis_substrait/compiler/mapping.py
+++ b/ibis_substrait/compiler/mapping.py
@@ -174,11 +174,12 @@ class FunctionEntry:
 
 
 def _parse_func(entry: Mapping[str, Any]) -> Iterator[FunctionEntry]:
-    for impl in entry["impls"]:
-        sf = FunctionEntry(entry["name"])
-        sf.parse(impl)
+    if "impls" in entry.keys():
+        for impl in entry["impls"]:
+            sf = FunctionEntry(entry["name"])
+            sf.parse(impl)
 
-        yield sf
+            yield sf
 
 
 def register_extension_yaml(


### PR DESCRIPTION
The recent addition of https://substrait.io/extensions/functions_geometry/
is breaking the parsing because the first dictionary entry is a custom data type
rather than an actual function.  The data type has no impls.

```
    for impl in entry["impls"]:
E   KeyError: 'impls'
```
