### PR TITLE
chore(renovate): ignore substrait updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,6 @@
   "lockFileMaintenance": { "enabled": true },
   "automerge": true,
   "labels": ["dependencies"],
-  "ignoreDeps": ["protobuf"],
+  "ignoreDeps": ["protobuf", "substrait"],
   "schedule": ["after 5pm on friday"]
 }


### PR DESCRIPTION
Updating substrait requires regenerating snapshot files so the
auto-update PR will always fail.  Skipping it, since I'm already
manually updating the upstream package.
