### PR TITLE
fix(grouping): collect multiple grouping keys in single "groupings"

### DIFF
--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
@@ -243,11 +243,7 @@
                           },
                           "rootReference": {}
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "groupingExpressions": [
+                      },
                       {
                         "selection": {
                           "directReference": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
@@ -567,11 +567,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -581,11 +577,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
@@ -370,6 +370,9 @@
                 }
               }
             },
+            "groupings": [
+              {}
+            ],
             "measures": [
               {
                 "measure": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
@@ -1128,11 +1128,7 @@
                           },
                           "rootReference": {}
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "groupingExpressions": [
+                      },
                       {
                         "selection": {
                           "directReference": {
@@ -1142,11 +1138,7 @@
                           },
                           "rootReference": {}
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "groupingExpressions": [
+                      },
                       {
                         "selection": {
                           "directReference": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h091/tpc_h091.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h091/tpc_h091.json
@@ -1037,11 +1037,7 @@
                           },
                           "rootReference": {}
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "groupingExpressions": [
+                      },
                       {
                         "selection": {
                           "directReference": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h092/tpc_h092.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h092/tpc_h092.json
@@ -1025,11 +1025,7 @@
                           },
                           "rootReference": {}
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "groupingExpressions": [
+                      },
                       {
                         "selection": {
                           "directReference": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
@@ -651,11 +651,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -665,11 +661,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -679,11 +671,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -693,11 +681,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -707,11 +691,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -721,11 +701,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
@@ -427,11 +427,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -439,11 +435,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -453,11 +445,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {
@@ -467,11 +455,7 @@
                               },
                               "rootReference": {}
                             }
-                          }
-                        ]
-                      },
-                      {
-                        "groupingExpressions": [
+                          },
                           {
                             "selection": {
                               "directReference": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
@@ -1322,6 +1322,9 @@
                 }
               }
             },
+            "groupings": [
+              {}
+            ],
             "measures": [
               {
                 "measure": {

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -525,3 +525,13 @@ def test_aggregate_filter_select_output_mapping(compiler):
 def test_filter_over_subquery(compiler):
     t = ibis.table([("a", "int")], name="t").filter(_.a > _.a.mean())
     translate(t, compiler=compiler)
+
+
+def test_groupby_multiple_keys(compiler):
+    t = ibis.table(name="t", schema=(("a", "int"), ("b", "int")))
+    expr = t.group_by(["a", "b"]).agg()
+    plan = translate(expr, compiler=compiler)
+
+    # There should be one grouping with two separate expressions inside
+    assert len(plan.aggregate.groupings) == 1
+    assert len(plan.aggregate.groupings[0].grouping_expressions) == 2


### PR DESCRIPTION
Also updated our selection routine to properly handle the flattened index count for projecting out of these groupbys.

Fixes #878 