### PR TITLE
fix(field_index): get field index w.r.t. pre-join table schemata

### DIFF
--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -712,19 +712,17 @@ def table_column(
         # Join reference containing the field we care about
         field_table = op.rel.values.get(op.name).rel
         # Index of that join reference in the list of join references
-        field_table_index = op.rel.tables.index(field_table)
+        field_table_index = join_tables.index(field_table)
 
-        join_table_offset = 0
         # Offset by the number of columns in each preceding table
-        for i in range(field_table_index):
-            join_table_offset += len(join_tables[i].schema)
+        join_table_offset = sum(
+            len(join_tables[i].schema) for i in range(field_table_index)
+        )
         # Then add on the index of the column in the table
         # Also in the event of renaming due to join collisions, resolve
         # the renamed column to the original name so we can pull it off the parent table
         orig_name = op.rel.values[op.name].name
-        relative_offset = join_table_offset + field_table.schema._name_locs.get(
-            orig_name
-        )
+        relative_offset = join_table_offset + field_table.schema._name_locs[orig_name]
     else:
         schema = op.rel.schema
         relative_offset = schema._name_locs[op.name]

--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -674,8 +674,60 @@ def table_column(
     else:
         base_offset = 0
 
-    schema = op.rel.schema
-    relative_offset = schema._name_locs[op.name]
+    if isinstance(op.rel, ops.JoinChain):
+        # JoinChains provide the schema of the joined table (which is great for Ibis)
+        # but for substrait we need the Field index computed with respect to
+        # the original table schemas.  In practice, this means rolling through
+        # the tables in a JoinChain and computing the field index _without_
+        # removing the join key
+        #
+        # Given
+        # Table 1
+        #   a: int
+        #   b: int
+        #
+        # Table 2
+        #   a: int
+        #   c: int
+        #
+        # JoinChain[r0]
+        #  JoinLink[inner, r1]
+        #    r0.a == r1.a
+        #  values:
+        #    a: r0.a
+        #    b: r0.b
+        #    c: r1.c
+        #
+        # If we ask for the field index of `c`, the JoinChain schema will give
+        # us an index of `2`, but it should be `3` because
+        #
+        #  0: table 1 a
+        #  1: table 1 b
+        #  2: table 2 a
+        #  3: table 2 c
+        #
+
+        # List of join reference objects
+        join_tables = op.rel.tables
+        # Join reference containing the field we care about
+        field_table = op.rel.values.get(op.name).rel
+        # Index of that join reference in the list of join references
+        field_table_index = op.rel.tables.index(field_table)
+
+        join_table_offset = 0
+        # Offset by the number of columns in each preceding table
+        for i in range(field_table_index):
+            join_table_offset += len(join_tables[i].schema)
+        # Then add on the index of the column in the table
+        # Also in the event of renaming due to join collisions, resolve
+        # the renamed column to the original name so we can pull it off the parent table
+        orig_name = op.rel.values[op.name].name
+        relative_offset = join_table_offset + field_table.schema._name_locs.get(
+            orig_name
+        )
+    else:
+        schema = op.rel.schema
+        relative_offset = schema._name_locs[op.name]
     absolute_offset = base_offset + relative_offset
     return stalg.Expression(
         selection=stalg.Expression.FieldReference(

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
@@ -732,7 +732,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 1
+                                                            "field": 45
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -764,7 +764,9 @@
                                                     "value": {
                                                       "selection": {
                                                         "directReference": {
-                                                          "structField": {}
+                                                          "structField": {
+                                                            "field": 41
+                                                          }
                                                         },
                                                         "rootReference": {}
                                                       }
@@ -810,7 +812,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 1
+                                                            "field": 45
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -842,7 +844,9 @@
                                                     "value": {
                                                       "selection": {
                                                         "directReference": {
-                                                          "structField": {}
+                                                          "structField": {
+                                                            "field": 41
+                                                          }
                                                         },
                                                         "rootReference": {}
                                                       }
@@ -882,7 +886,7 @@
                                       "selection": {
                                         "directReference": {
                                           "structField": {
-                                            "field": 2
+                                            "field": 17
                                           }
                                         },
                                         "rootReference": {}

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
@@ -957,7 +957,7 @@
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 3
+                                                                "field": 54
                                                               }
                                                             },
                                                             "rootReference": {}
@@ -990,7 +990,7 @@
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 4
+                                                                "field": 36
                                                               }
                                                             },
                                                             "rootReference": {}
@@ -1034,7 +1034,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 5
+                                                        "field": 4
                                                       }
                                                     },
                                                     "rootReference": {}

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
@@ -767,7 +767,7 @@
                               "selection": {
                                 "directReference": {
                                   "structField": {
-                                    "field": 3
+                                    "field": 29
                                   }
                                 },
                                 "rootReference": {}

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
@@ -555,7 +555,7 @@
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 1
+                                                                        "field": 25
                                                                       }
                                                                     },
                                                                     "rootReference": {}
@@ -588,7 +588,7 @@
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 2
+                                                                        "field": 19
                                                                       }
                                                                     },
                                                                     "rootReference": {}
@@ -600,7 +600,7 @@
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 3
+                                                                        "field": 18
                                                                       }
                                                                     },
                                                                     "rootReference": {}
@@ -630,7 +630,7 @@
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 6
+                                                                "field": 33
                                                               }
                                                             },
                                                             "rootReference": {}
@@ -817,7 +817,9 @@
                                                                   "value": {
                                                                     "selection": {
                                                                       "directReference": {
-                                                                        "structField": {}
+                                                                        "structField": {
+                                                                          "field": 7
+                                                                        }
                                                                       },
                                                                       "rootReference": {}
                                                                     }
@@ -854,7 +856,7 @@
                                                                     "selection": {
                                                                       "directReference": {
                                                                         "structField": {
-                                                                          "field": 4
+                                                                          "field": 9
                                                                         }
                                                                       },
                                                                       "rootReference": {}
@@ -1063,7 +1065,9 @@
                                                                           "value": {
                                                                             "selection": {
                                                                               "directReference": {
-                                                                                "structField": {}
+                                                                                "structField": {
+                                                                                  "field": 7
+                                                                                }
                                                                               },
                                                                               "rootReference": {}
                                                                             }
@@ -1100,7 +1104,7 @@
                                                                             "selection": {
                                                                               "directReference": {
                                                                                 "structField": {
-                                                                                  "field": 4
+                                                                                  "field": 9
                                                                                 }
                                                                               },
                                                                               "rootReference": {}


### PR DESCRIPTION
JoinChains provide the schema of the joined table (which is great for Ibis)
but for substrait we need the Field index computed with respect to
the original table schemata.  In practice, this means rolling through
the tables in a JoinChain and computing the field index _without_
removing the join key

Given
```
Table 1
  a: int
  b: int

Table 2
  a: int
  c: int

JoinChain[r0]
 JoinLink[inner, r1]
   r0.a == r1.a
 values:
   a: r0.a
   b: r0.b
   c: r1.c
```

If we ask for the field index of `c`, the JoinChain schema will give
us an index of `2`, but it should be `3` because

```
 0: table 1 a
 1: table 1 b
 2: table 2 a
 3: table 2 c
```

So now we pull out the correct JoinReference object and use that to
index into the tables in the JoinChain and offset by the length of the
schema of those preceding tables.

Resolves #1072