### PR TITLE
fix: handle projections after join chain

### DIFF
--- a/ibis_substrait/compiler/translate.py
+++ b/ibis_substrait/compiler/translate.py
@@ -818,11 +818,11 @@ def filter(
 def apply_projection(
     schema_len: int,
     relation: stalg.Rel,
-    values,
+    values: Mapping[str, ops.Value],
     compiler: SubstraitCompiler,
-    child_rel_field_offsets,
-    kwargs,
-):
+    child_rel_field_offsets: Mapping[ops.TableNode, int] | None,
+    kwargs: Mapping,
+) -> stalg.ReadRel:
     mapping_counter = itertools.count(schema_len)
 
     return stalg.Rel(

--- a/ibis_substrait/tests/compiler/parity_utils.py
+++ b/ibis_substrait/tests/compiler/parity_utils.py
@@ -62,4 +62,5 @@ class DatafusionSubstraitConsumer(SubstraitConsumer):
             df = df.with_column_renamed(
                 column_name, plan.relations[0].root.names[column_number]
             )
-        return df.to_arrow_table()
+        record_batch = df.collect()
+        return pa.Table.from_batches(record_batch)

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h02/tpc_h02.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h02/tpc_h02.json
@@ -73,88 +73,214 @@
                     "input": {
                       "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  28,
+                                  29,
+                                  30,
+                                  31,
+                                  32,
+                                  33,
+                                  34,
+                                  35,
+                                  36,
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42,
+                                  43,
+                                  44,
+                                  45,
+                                  46,
+                                  47,
+                                  48,
+                                  49,
+                                  50,
+                                  51,
+                                  52,
+                                  53,
+                                  54,
+                                  55
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
                                   "join": {
                                     "left": {
                                       "join": {
                                         "left": {
-                                          "read": {
-                                            "common": {
-                                              "direct": {}
-                                            },
-                                            "baseSchema": {
-                                              "names": [
-                                                "p_partkey",
-                                                "p_name",
-                                                "p_mfgr",
-                                                "p_brand",
-                                                "p_type",
-                                                "p_size",
-                                                "p_container",
-                                                "p_retailprice",
-                                                "p_comment"
-                                              ],
-                                              "struct": {
-                                                "types": [
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
+                                          "join": {
+                                            "left": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "p_partkey",
+                                                    "p_name",
+                                                    "p_mfgr",
+                                                    "p_brand",
+                                                    "p_type",
+                                                    "p_size",
+                                                    "p_container",
+                                                    "p_retailprice",
+                                                    "p_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
                                                   }
-                                                ],
-                                                "nullability": "NULLABILITY_REQUIRED"
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "part"
+                                                  ]
+                                                }
                                               }
                                             },
-                                            "namedTable": {
-                                              "names": [
-                                                "part"
-                                              ]
-                                            }
+                                            "right": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "ps_partkey",
+                                                    "ps_suppkey",
+                                                    "ps_availqty",
+                                                    "ps_supplycost",
+                                                    "ps_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                  }
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "partsupp"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expression": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 9
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "JOIN_TYPE_INNER"
                                           }
                                         },
                                         "right": {
@@ -164,11 +290,13 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "ps_partkey",
-                                                "ps_suppkey",
-                                                "ps_availqty",
-                                                "ps_supplycost",
-                                                "ps_comment"
+                                                "s_suppkey",
+                                                "s_name",
+                                                "s_address",
+                                                "s_nationkey",
+                                                "s_phone",
+                                                "s_acctbal",
+                                                "s_comment"
                                               ],
                                               "struct": {
                                                 "types": [
@@ -178,12 +306,22 @@
                                                     }
                                                   },
                                                   {
-                                                    "i32": {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
@@ -205,7 +343,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "partsupp"
+                                                "supplier"
                                               ]
                                             }
                                           }
@@ -223,7 +361,9 @@
                                                 "value": {
                                                   "selection": {
                                                     "directReference": {
-                                                      "structField": {}
+                                                      "structField": {
+                                                        "field": 14
+                                                      }
                                                     },
                                                     "rootReference": {}
                                                   }
@@ -234,7 +374,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 9
+                                                        "field": 10
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -254,13 +394,10 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "s_suppkey",
-                                            "s_name",
-                                            "s_address",
-                                            "s_nationkey",
-                                            "s_phone",
-                                            "s_acctbal",
-                                            "s_comment"
+                                            "n_nationkey",
+                                            "n_name",
+                                            "n_regionkey",
+                                            "n_comment"
                                           ],
                                           "struct": {
                                             "types": [
@@ -275,24 +412,7 @@
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
                                                 "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -307,7 +427,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "supplier"
+                                            "nation"
                                           ]
                                         }
                                       }
@@ -326,7 +446,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 14
+                                                    "field": 17
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -338,7 +458,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 10
+                                                    "field": 21
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -358,10 +478,9 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "n_nationkey",
-                                        "n_name",
-                                        "n_regionkey",
-                                        "n_comment"
+                                        "r_regionkey",
+                                        "r_name",
+                                        "r_comment"
                                       ],
                                       "struct": {
                                         "types": [
@@ -376,11 +495,6 @@
                                             }
                                           },
                                           {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
                                             "string": {
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
@@ -391,7 +505,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "nation"
+                                        "region"
                                       ]
                                     }
                                   }
@@ -410,7 +524,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 17
+                                                "field": 23
                                               }
                                             },
                                             "rootReference": {}
@@ -422,7 +536,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 21
+                                                "field": 25
                                               }
                                             },
                                             "rootReference": {}
@@ -435,82 +549,286 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "r_regionkey",
-                                    "r_name",
-                                    "r_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "region"
-                                  ]
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
                                 }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 23
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 25
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
                                     }
-                                  }
-                                ]
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 25
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 26
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 27
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
                               }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
                         },
                         "condition": {
@@ -680,62 +998,193 @@
                                                   "input": {
                                                     "filter": {
                                                       "input": {
-                                                        "join": {
-                                                          "left": {
+                                                        "project": {
+                                                          "common": {
+                                                            "emit": {
+                                                              "outputMapping": [
+                                                                19,
+                                                                20,
+                                                                21,
+                                                                22,
+                                                                23,
+                                                                24,
+                                                                25,
+                                                                26,
+                                                                27,
+                                                                28,
+                                                                29,
+                                                                30,
+                                                                31,
+                                                                32,
+                                                                33,
+                                                                34,
+                                                                35,
+                                                                36,
+                                                                37
+                                                              ]
+                                                            }
+                                                          },
+                                                          "input": {
                                                             "join": {
                                                               "left": {
                                                                 "join": {
                                                                   "left": {
-                                                                    "read": {
-                                                                      "common": {
-                                                                        "direct": {}
-                                                                      },
-                                                                      "baseSchema": {
-                                                                        "names": [
-                                                                          "ps_partkey",
-                                                                          "ps_suppkey",
-                                                                          "ps_availqty",
-                                                                          "ps_supplycost",
-                                                                          "ps_comment"
-                                                                        ],
-                                                                        "struct": {
-                                                                          "types": [
-                                                                            {
-                                                                              "i32": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "i32": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "i32": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "decimal": {
-                                                                                "scale": 2,
-                                                                                "precision": 15,
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "string": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
+                                                                    "join": {
+                                                                      "left": {
+                                                                        "read": {
+                                                                          "common": {
+                                                                            "direct": {}
+                                                                          },
+                                                                          "baseSchema": {
+                                                                            "names": [
+                                                                              "ps_partkey",
+                                                                              "ps_suppkey",
+                                                                              "ps_availqty",
+                                                                              "ps_supplycost",
+                                                                              "ps_comment"
+                                                                            ],
+                                                                            "struct": {
+                                                                              "types": [
+                                                                                {
+                                                                                  "i32": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "i32": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "i32": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "decimal": {
+                                                                                    "scale": 2,
+                                                                                    "precision": 15,
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                }
+                                                                              ],
+                                                                              "nullability": "NULLABILITY_REQUIRED"
                                                                             }
-                                                                          ],
-                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                          },
+                                                                          "namedTable": {
+                                                                            "names": [
+                                                                              "partsupp"
+                                                                            ]
+                                                                          }
                                                                         }
                                                                       },
-                                                                      "namedTable": {
-                                                                        "names": [
-                                                                          "partsupp"
-                                                                        ]
-                                                                      }
+                                                                      "right": {
+                                                                        "read": {
+                                                                          "common": {
+                                                                            "direct": {}
+                                                                          },
+                                                                          "baseSchema": {
+                                                                            "names": [
+                                                                              "s_suppkey",
+                                                                              "s_name",
+                                                                              "s_address",
+                                                                              "s_nationkey",
+                                                                              "s_phone",
+                                                                              "s_acctbal",
+                                                                              "s_comment"
+                                                                            ],
+                                                                            "struct": {
+                                                                              "types": [
+                                                                                {
+                                                                                  "i32": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "i32": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "decimal": {
+                                                                                    "scale": 2,
+                                                                                    "precision": 15,
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                }
+                                                                              ],
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          "namedTable": {
+                                                                            "names": [
+                                                                              "supplier"
+                                                                            ]
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "expression": {
+                                                                        "scalarFunction": {
+                                                                          "functionReference": 1,
+                                                                          "outputType": {
+                                                                            "bool": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          "arguments": [
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
+                                                                                      "field": 5
+                                                                                    }
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
+                                                                                      "field": 1
+                                                                                    }
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "JOIN_TYPE_INNER"
                                                                     }
                                                                   },
                                                                   "right": {
@@ -745,13 +1194,10 @@
                                                                       },
                                                                       "baseSchema": {
                                                                         "names": [
-                                                                          "s_suppkey",
-                                                                          "s_name",
-                                                                          "s_address",
-                                                                          "s_nationkey",
-                                                                          "s_phone",
-                                                                          "s_acctbal",
-                                                                          "s_comment"
+                                                                          "n_nationkey",
+                                                                          "n_name",
+                                                                          "n_regionkey",
+                                                                          "n_comment"
                                                                         ],
                                                                         "struct": {
                                                                           "types": [
@@ -766,24 +1212,7 @@
                                                                               }
                                                                             },
                                                                             {
-                                                                              "string": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
                                                                               "i32": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "string": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "decimal": {
-                                                                                "scale": 2,
-                                                                                "precision": 15,
                                                                                 "nullability": "NULLABILITY_REQUIRED"
                                                                               }
                                                                             },
@@ -798,7 +1227,7 @@
                                                                       },
                                                                       "namedTable": {
                                                                         "names": [
-                                                                          "supplier"
+                                                                          "nation"
                                                                         ]
                                                                       }
                                                                     }
@@ -817,7 +1246,7 @@
                                                                             "selection": {
                                                                               "directReference": {
                                                                                 "structField": {
-                                                                                  "field": 5
+                                                                                  "field": 8
                                                                                 }
                                                                               },
                                                                               "rootReference": {}
@@ -829,7 +1258,7 @@
                                                                             "selection": {
                                                                               "directReference": {
                                                                                 "structField": {
-                                                                                  "field": 1
+                                                                                  "field": 12
                                                                                 }
                                                                               },
                                                                               "rootReference": {}
@@ -849,10 +1278,9 @@
                                                                   },
                                                                   "baseSchema": {
                                                                     "names": [
-                                                                      "n_nationkey",
-                                                                      "n_name",
-                                                                      "n_regionkey",
-                                                                      "n_comment"
+                                                                      "r_regionkey",
+                                                                      "r_name",
+                                                                      "r_comment"
                                                                     ],
                                                                     "struct": {
                                                                       "types": [
@@ -867,11 +1295,6 @@
                                                                           }
                                                                         },
                                                                         {
-                                                                          "i32": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
                                                                           "string": {
                                                                             "nullability": "NULLABILITY_REQUIRED"
                                                                           }
@@ -882,7 +1305,7 @@
                                                                   },
                                                                   "namedTable": {
                                                                     "names": [
-                                                                      "nation"
+                                                                      "region"
                                                                     ]
                                                                   }
                                                                 }
@@ -901,7 +1324,7 @@
                                                                         "selection": {
                                                                           "directReference": {
                                                                             "structField": {
-                                                                              "field": 8
+                                                                              "field": 14
                                                                             }
                                                                           },
                                                                           "rootReference": {}
@@ -913,7 +1336,7 @@
                                                                         "selection": {
                                                                           "directReference": {
                                                                             "structField": {
-                                                                              "field": 12
+                                                                              "field": 16
                                                                             }
                                                                           },
                                                                           "rootReference": {}
@@ -926,82 +1349,196 @@
                                                               "type": "JOIN_TYPE_INNER"
                                                             }
                                                           },
-                                                          "right": {
-                                                            "read": {
-                                                              "common": {
-                                                                "direct": {}
-                                                              },
-                                                              "baseSchema": {
-                                                                "names": [
-                                                                  "r_regionkey",
-                                                                  "r_name",
-                                                                  "r_comment"
-                                                                ],
-                                                                "struct": {
-                                                                  "types": [
-                                                                    {
-                                                                      "i32": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    }
-                                                                  ],
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              "namedTable": {
-                                                                "names": [
-                                                                  "region"
-                                                                ]
+                                                          "expressions": [
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {}
+                                                                },
+                                                                "rootReference": {}
                                                               }
-                                                            }
-                                                          },
-                                                          "expression": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 1,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 14
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 1
                                                                   }
                                                                 },
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 16
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 2
                                                                   }
-                                                                }
-                                                              ]
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 3
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 4
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 5
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 6
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 7
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 8
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 9
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 10
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 11
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 12
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 13
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 14
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 15
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 16
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 17
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 18
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
                                                             }
-                                                          },
-                                                          "type": "JOIN_TYPE_INNER"
+                                                          ]
                                                         }
                                                       },
                                                       "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
@@ -76,78 +76,233 @@
                     "input": {
                       "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  33,
+                                  34,
+                                  35,
+                                  36,
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42,
+                                  43,
+                                  44,
+                                  45,
+                                  46,
+                                  47,
+                                  48,
+                                  49,
+                                  50,
+                                  51,
+                                  52,
+                                  53,
+                                  54,
+                                  55,
+                                  56,
+                                  57,
+                                  58,
+                                  59,
+                                  60,
+                                  61,
+                                  62,
+                                  63,
+                                  64,
+                                  65
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "c_custkey",
-                                        "c_name",
-                                        "c_address",
-                                        "c_nationkey",
-                                        "c_phone",
-                                        "c_acctbal",
-                                        "c_mktsegment",
-                                        "c_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
+                                  "join": {
+                                    "left": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "c_custkey",
+                                            "c_name",
+                                            "c_address",
+                                            "c_nationkey",
+                                            "c_phone",
+                                            "c_acctbal",
+                                            "c_mktsegment",
+                                            "c_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
                                           }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "customer"
+                                          ]
+                                        }
                                       }
                                     },
-                                    "namedTable": {
-                                      "names": [
-                                        "customer"
-                                      ]
-                                    }
+                                    "right": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "o_orderkey",
+                                            "o_custkey",
+                                            "o_orderstatus",
+                                            "o_totalprice",
+                                            "o_orderdate",
+                                            "o_orderpriority",
+                                            "o_clerk",
+                                            "o_shippriority",
+                                            "o_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                          }
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "orders"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "expression": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {}
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 9
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "JOIN_TYPE_INNER"
                                   }
                                 },
                                 "right": {
@@ -157,63 +312,111 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "o_orderkey",
-                                        "o_custkey",
-                                        "o_orderstatus",
-                                        "o_totalprice",
-                                        "o_orderdate",
-                                        "o_orderpriority",
-                                        "o_clerk",
-                                        "o_shippriority",
-                                        "o_comment"
+                                        "l_orderkey",
+                                        "l_partkey",
+                                        "l_suppkey",
+                                        "l_linenumber",
+                                        "l_quantity",
+                                        "l_extendedprice",
+                                        "l_discount",
+                                        "l_tax",
+                                        "l_returnflag",
+                                        "l_linestatus",
+                                        "l_shipdate",
+                                        "l_commitdate",
+                                        "l_receiptdate",
+                                        "l_shipinstruct",
+                                        "l_shipmode",
+                                        "l_comment"
                                       ],
                                       "struct": {
                                         "types": [
                                           {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "decimal": {
                                               "scale": 2,
                                               "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "date": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           }
                                         ],
@@ -222,7 +425,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "orders"
+                                        "lineitem"
                                       ]
                                     }
                                   }
@@ -240,7 +443,9 @@
                                         "value": {
                                           "selection": {
                                             "directReference": {
-                                              "structField": {}
+                                              "structField": {
+                                                "field": 17
+                                              }
                                             },
                                             "rootReference": {}
                                           }
@@ -251,7 +456,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 9
+                                                "field": 8
                                               }
                                             },
                                             "rootReference": {}
@@ -264,168 +469,336 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "l_orderkey",
-                                    "l_partkey",
-                                    "l_suppkey",
-                                    "l_linenumber",
-                                    "l_quantity",
-                                    "l_extendedprice",
-                                    "l_discount",
-                                    "l_tax",
-                                    "l_returnflag",
-                                    "l_linestatus",
-                                    "l_shipdate",
-                                    "l_commitdate",
-                                    "l_receiptdate",
-                                    "l_shipinstruct",
-                                    "l_shipmode",
-                                    "l_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "lineitem"
-                                  ]
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
                                 }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 17
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 8
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
                                     }
-                                  }
-                                ]
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 25
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 26
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 27
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 28
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 29
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 30
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 31
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 32
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
                               }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
                         },
                         "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
@@ -74,8 +74,61 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              47,
+                              48,
+                              49,
+                              50,
+                              51,
+                              52,
+                              53,
+                              54,
+                              55,
+                              56,
+                              57,
+                              58,
+                              59,
+                              60,
+                              61,
+                              62,
+                              63,
+                              64,
+                              65,
+                              66,
+                              67,
+                              68,
+                              69,
+                              70,
+                              71,
+                              72,
+                              73,
+                              74,
+                              75,
+                              76,
+                              77,
+                              78,
+                              79,
+                              80,
+                              81,
+                              82,
+                              83,
+                              84,
+                              85,
+                              86,
+                              87,
+                              88,
+                              89,
+                              90,
+                              91,
+                              92,
+                              93
+                            ]
+                          }
+                        },
+                        "input": {
                           "join": {
                             "left": {
                               "join": {
@@ -84,74 +137,190 @@
                                     "left": {
                                       "join": {
                                         "left": {
-                                          "read": {
-                                            "common": {
-                                              "direct": {}
-                                            },
-                                            "baseSchema": {
-                                              "names": [
-                                                "c_custkey",
-                                                "c_name",
-                                                "c_address",
-                                                "c_nationkey",
-                                                "c_phone",
-                                                "c_acctbal",
-                                                "c_mktsegment",
-                                                "c_comment"
-                                              ],
-                                              "struct": {
-                                                "types": [
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
+                                          "join": {
+                                            "left": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "c_custkey",
+                                                    "c_name",
+                                                    "c_address",
+                                                    "c_nationkey",
+                                                    "c_phone",
+                                                    "c_acctbal",
+                                                    "c_mktsegment",
+                                                    "c_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
                                                   }
-                                                ],
-                                                "nullability": "NULLABILITY_REQUIRED"
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "customer"
+                                                  ]
+                                                }
                                               }
                                             },
-                                            "namedTable": {
-                                              "names": [
-                                                "customer"
-                                              ]
-                                            }
+                                            "right": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "o_orderkey",
+                                                    "o_custkey",
+                                                    "o_orderstatus",
+                                                    "o_totalprice",
+                                                    "o_orderdate",
+                                                    "o_orderpriority",
+                                                    "o_clerk",
+                                                    "o_shippriority",
+                                                    "o_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                  }
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "orders"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expression": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 9
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "JOIN_TYPE_INNER"
                                           }
                                         },
                                         "right": {
@@ -161,63 +330,111 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "o_orderkey",
-                                                "o_custkey",
-                                                "o_orderstatus",
-                                                "o_totalprice",
-                                                "o_orderdate",
-                                                "o_orderpriority",
-                                                "o_clerk",
-                                                "o_shippriority",
-                                                "o_comment"
+                                                "l_orderkey",
+                                                "l_partkey",
+                                                "l_suppkey",
+                                                "l_linenumber",
+                                                "l_quantity",
+                                                "l_extendedprice",
+                                                "l_discount",
+                                                "l_tax",
+                                                "l_returnflag",
+                                                "l_linestatus",
+                                                "l_shipdate",
+                                                "l_commitdate",
+                                                "l_receiptdate",
+                                                "l_shipinstruct",
+                                                "l_shipmode",
+                                                "l_comment"
                                               ],
                                               "struct": {
                                                 "types": [
                                                   {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "decimal": {
                                                       "scale": 2,
                                                       "precision": 15,
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "date": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   }
                                                 ],
@@ -226,7 +443,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "orders"
+                                                "lineitem"
                                               ]
                                             }
                                           }
@@ -244,7 +461,9 @@
                                                 "value": {
                                                   "selection": {
                                                     "directReference": {
-                                                      "structField": {}
+                                                      "structField": {
+                                                        "field": 17
+                                                      }
                                                     },
                                                     "rootReference": {}
                                                   }
@@ -255,7 +474,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 9
+                                                        "field": 8
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -275,111 +494,51 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "l_orderkey",
-                                            "l_partkey",
-                                            "l_suppkey",
-                                            "l_linenumber",
-                                            "l_quantity",
-                                            "l_extendedprice",
-                                            "l_discount",
-                                            "l_tax",
-                                            "l_returnflag",
-                                            "l_linestatus",
-                                            "l_shipdate",
-                                            "l_commitdate",
-                                            "l_receiptdate",
-                                            "l_shipinstruct",
-                                            "l_shipmode",
-                                            "l_comment"
+                                            "s_suppkey",
+                                            "s_name",
+                                            "s_address",
+                                            "s_nationkey",
+                                            "s_phone",
+                                            "s_acctbal",
+                                            "s_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "decimal": {
                                                   "scale": 2,
                                                   "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               }
                                             ],
@@ -388,7 +547,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "lineitem"
+                                            "supplier"
                                           ]
                                         }
                                       }
@@ -407,7 +566,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 17
+                                                    "field": 19
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -419,7 +578,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 8
+                                                    "field": 33
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -439,13 +598,10 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "s_suppkey",
-                                        "s_name",
-                                        "s_address",
-                                        "s_nationkey",
-                                        "s_phone",
-                                        "s_acctbal",
-                                        "s_comment"
+                                        "n_nationkey",
+                                        "n_name",
+                                        "n_regionkey",
+                                        "n_comment"
                                       ],
                                       "struct": {
                                         "types": [
@@ -460,24 +616,7 @@
                                             }
                                           },
                                           {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
                                             "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
@@ -492,14 +631,14 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "supplier"
+                                        "nation"
                                       ]
                                     }
                                   }
                                 },
                                 "expression": {
                                   "scalarFunction": {
-                                    "functionReference": 1,
+                                    "functionReference": 2,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_NULLABLE"
@@ -508,25 +647,77 @@
                                     "arguments": [
                                       {
                                         "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 19
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
                                               }
                                             },
-                                            "rootReference": {}
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 3
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 36
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              }
+                                            ]
                                           }
                                         }
                                       },
                                       {
                                         "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 33
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
                                               }
                                             },
-                                            "rootReference": {}
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 36
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 40
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              }
+                                            ]
                                           }
                                         }
                                       }
@@ -543,10 +734,9 @@
                                 },
                                 "baseSchema": {
                                   "names": [
-                                    "n_nationkey",
-                                    "n_name",
-                                    "n_regionkey",
-                                    "n_comment"
+                                    "r_regionkey",
+                                    "r_name",
+                                    "r_comment"
                                   ],
                                   "struct": {
                                     "types": [
@@ -561,11 +751,6 @@
                                         }
                                       },
                                       {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
                                         "string": {
                                           "nullability": "NULLABILITY_REQUIRED"
                                         }
@@ -576,14 +761,14 @@
                                 },
                                 "namedTable": {
                                   "names": [
-                                    "nation"
+                                    "region"
                                   ]
                                 }
                               }
                             },
                             "expression": {
                               "scalarFunction": {
-                                "functionReference": 2,
+                                "functionReference": 1,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_NULLABLE"
@@ -592,77 +777,25 @@
                                 "arguments": [
                                   {
                                     "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 1,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 42
                                           }
                                         },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 3
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 36
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          }
-                                        ]
+                                        "rootReference": {}
                                       }
                                     }
                                   },
                                   {
                                     "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 1,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 44
                                           }
                                         },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 36
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 40
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          }
-                                        ]
+                                        "rootReference": {}
                                       }
                                     }
                                   }
@@ -672,82 +805,476 @@
                             "type": "JOIN_TYPE_INNER"
                           }
                         },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "r_regionkey",
-                                "r_name",
-                                "r_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "region"
-                              ]
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
                             }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 42
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
                                 }
                               },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 44
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
                                 }
-                              }
-                            ]
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 11
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 14
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 15
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 16
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 17
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 18
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 19
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 20
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 21
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 22
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 23
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 24
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 25
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 26
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 27
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 28
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 29
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 30
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 31
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 32
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 33
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 34
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 35
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 36
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 37
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 38
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 39
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 40
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 41
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 42
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 43
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 44
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 45
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 46
+                                }
+                              },
+                              "rootReference": {}
+                            }
                           }
-                        },
-                        "type": "JOIN_TYPE_INNER"
+                        ]
                       }
                     },
                     "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
@@ -6,11 +6,15 @@
     },
     {
       "extensionUriAnchor": 2,
-      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_boolean.yaml"
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_datetime.yaml"
     },
     {
       "extensionUriAnchor": 3,
       "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic_decimal.yaml"
+    },
+    {
+      "extensionUriAnchor": 4,
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_boolean.yaml"
     }
   ],
   "extensions": [
@@ -25,27 +29,48 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
+        "name": "extract:date"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 3,
+        "name": "multiply:dec_dec"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 4,
+        "name": "subtract:dec_dec"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 4,
+        "functionAnchor": 5,
         "name": "and:bool"
       }
     },
     {
       "extensionFunction": {
-        "extensionUriReference": 2,
-        "functionAnchor": 3,
+        "extensionUriReference": 4,
+        "functionAnchor": 6,
         "name": "or:bool"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 1,
-        "functionAnchor": 4,
+        "functionAnchor": 7,
         "name": "between:any_any_any"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
-        "functionAnchor": 5,
+        "functionAnchor": 8,
         "name": "sum:dec"
       }
     }
@@ -60,8 +85,21 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              48,
+                              49,
+                              50,
+                              51,
+                              52,
+                              53,
+                              54
+                            ]
+                          }
+                        },
+                        "input": {
                           "join": {
                             "left": {
                               "join": {
@@ -70,68 +108,232 @@
                                     "left": {
                                       "join": {
                                         "left": {
-                                          "read": {
-                                            "common": {
-                                              "direct": {}
-                                            },
-                                            "baseSchema": {
-                                              "names": [
-                                                "s_suppkey",
-                                                "s_name",
-                                                "s_address",
-                                                "s_nationkey",
-                                                "s_phone",
-                                                "s_acctbal",
-                                                "s_comment"
-                                              ],
-                                              "struct": {
-                                                "types": [
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
+                                          "join": {
+                                            "left": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "s_suppkey",
+                                                    "s_name",
+                                                    "s_address",
+                                                    "s_nationkey",
+                                                    "s_phone",
+                                                    "s_acctbal",
+                                                    "s_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
                                                   }
-                                                ],
-                                                "nullability": "NULLABILITY_REQUIRED"
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "supplier"
+                                                  ]
+                                                }
                                               }
                                             },
-                                            "namedTable": {
-                                              "names": [
-                                                "supplier"
-                                              ]
-                                            }
+                                            "right": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "l_orderkey",
+                                                    "l_partkey",
+                                                    "l_suppkey",
+                                                    "l_linenumber",
+                                                    "l_quantity",
+                                                    "l_extendedprice",
+                                                    "l_discount",
+                                                    "l_tax",
+                                                    "l_returnflag",
+                                                    "l_linestatus",
+                                                    "l_shipdate",
+                                                    "l_commitdate",
+                                                    "l_receiptdate",
+                                                    "l_shipinstruct",
+                                                    "l_shipmode",
+                                                    "l_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                  }
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "lineitem"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expression": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 9
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "JOIN_TYPE_INNER"
                                           }
                                         },
                                         "right": {
@@ -141,111 +343,63 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "l_orderkey",
-                                                "l_partkey",
-                                                "l_suppkey",
-                                                "l_linenumber",
-                                                "l_quantity",
-                                                "l_extendedprice",
-                                                "l_discount",
-                                                "l_tax",
-                                                "l_returnflag",
-                                                "l_linestatus",
-                                                "l_shipdate",
-                                                "l_commitdate",
-                                                "l_receiptdate",
-                                                "l_shipinstruct",
-                                                "l_shipmode",
-                                                "l_comment"
+                                                "o_orderkey",
+                                                "o_custkey",
+                                                "o_orderstatus",
+                                                "o_totalprice",
+                                                "o_orderdate",
+                                                "o_orderpriority",
+                                                "o_clerk",
+                                                "o_shippriority",
+                                                "o_comment"
                                               ],
                                               "struct": {
                                                 "types": [
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   }
                                                 ],
@@ -254,7 +408,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "lineitem"
+                                                "orders"
                                               ]
                                             }
                                           }
@@ -272,7 +426,9 @@
                                                 "value": {
                                                   "selection": {
                                                     "directReference": {
-                                                      "structField": {}
+                                                      "structField": {
+                                                        "field": 23
+                                                      }
                                                     },
                                                     "rootReference": {}
                                                   }
@@ -283,7 +439,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 9
+                                                        "field": 7
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -303,20 +459,29 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "o_orderkey",
-                                            "o_custkey",
-                                            "o_orderstatus",
-                                            "o_totalprice",
-                                            "o_orderdate",
-                                            "o_orderpriority",
-                                            "o_clerk",
-                                            "o_shippriority",
-                                            "o_comment"
+                                            "c_custkey",
+                                            "c_name",
+                                            "c_address",
+                                            "c_nationkey",
+                                            "c_phone",
+                                            "c_acctbal",
+                                            "c_mktsegment",
+                                            "c_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
                                                 "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -338,22 +503,7 @@
                                                 }
                                               },
                                               {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -368,7 +518,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "orders"
+                                            "customer"
                                           ]
                                         }
                                       }
@@ -387,7 +537,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 23
+                                                    "field": 32
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -399,7 +549,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 7
+                                                    "field": 24
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -419,14 +569,10 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "c_custkey",
-                                        "c_name",
-                                        "c_address",
-                                        "c_nationkey",
-                                        "c_phone",
-                                        "c_acctbal",
-                                        "c_mktsegment",
-                                        "c_comment"
+                                        "n_nationkey",
+                                        "n_name",
+                                        "n_regionkey",
+                                        "n_comment"
                                       ],
                                       "struct": {
                                         "types": [
@@ -441,29 +587,7 @@
                                             }
                                           },
                                           {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
                                             "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
@@ -478,7 +602,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "customer"
+                                        "nation"
                                       ]
                                     }
                                   }
@@ -497,7 +621,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 32
+                                                "field": 3
                                               }
                                             },
                                             "rootReference": {}
@@ -509,7 +633,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 24
+                                                "field": 40
                                               }
                                             },
                                             "rootReference": {}
@@ -581,7 +705,7 @@
                                       "selection": {
                                         "directReference": {
                                           "structField": {
-                                            "field": 3
+                                            "field": 35
                                           }
                                         },
                                         "rootReference": {}
@@ -592,9 +716,7 @@
                                     "value": {
                                       "selection": {
                                         "directReference": {
-                                          "structField": {
-                                            "field": 40
-                                          }
+                                          "structField": {}
                                         },
                                         "rootReference": {}
                                       }
@@ -606,91 +728,173 @@
                             "type": "JOIN_TYPE_INNER"
                           }
                         },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "n_nationkey",
-                                "n_name",
-                                "n_regionkey",
-                                "n_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 41
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 17
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "cast": {
+                              "type": {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "input": {
+                                "scalarFunction": {
+                                  "functionReference": 2,
+                                  "outputType": {
                                     "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
+                                      "nullability": "NULLABILITY_NULLABLE"
                                     }
                                   },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
+                                  "arguments": [
+                                    {
+                                      "enum": "YEAR"
+                                    },
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 17
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      }
                                     }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
+                                  ]
+                                }
+                              },
+                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                            }
+                          },
+                          {
+                            "scalarFunction": {
+                              "functionReference": 3,
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 12
+                                        }
+                                      },
+                                      "rootReference": {}
                                     }
                                   }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "nation"
+                                },
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 4,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "cast": {
+                                              "type": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "input": {
+                                                "literal": {
+                                                  "i8": 1
+                                                }
+                                              },
+                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 13
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
                               ]
                             }
                           }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 35
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {}
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "type": "JOIN_TYPE_INNER"
+                        ]
                       }
                     },
                     "condition": {
                       "scalarFunction": {
-                        "functionReference": 2,
+                        "functionReference": 5,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_NULLABLE"
@@ -700,7 +904,7 @@
                           {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 3,
+                                "functionReference": 6,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_NULLABLE"
@@ -710,7 +914,7 @@
                                   {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 5,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_NULLABLE"
@@ -790,7 +994,7 @@
                                   {
                                     "value": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 5,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_NULLABLE"
@@ -874,7 +1078,7 @@
                           {
                             "value": {
                               "scalarFunction": {
-                                "functionReference": 4,
+                                "functionReference": 7,
                                 "outputType": {
                                   "bool": {
                                     "nullability": "NULLABILITY_NULLABLE"
@@ -953,7 +1157,7 @@
                 "measures": [
                   {
                     "measure": {
-                      "functionReference": 5,
+                      "functionReference": 8,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "decimal": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
@@ -6,11 +6,15 @@
     },
     {
       "extensionUriAnchor": 2,
-      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_boolean.yaml"
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_datetime.yaml"
     },
     {
       "extensionUriAnchor": 3,
       "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic_decimal.yaml"
+    },
+    {
+      "extensionUriAnchor": 4,
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_boolean.yaml"
     }
   ],
   "extensions": [
@@ -25,27 +29,48 @@
       "extensionFunction": {
         "extensionUriReference": 2,
         "functionAnchor": 2,
-        "name": "and:bool"
+        "name": "extract:date"
       }
     },
     {
       "extensionFunction": {
-        "extensionUriReference": 1,
+        "extensionUriReference": 3,
         "functionAnchor": 3,
-        "name": "between:any_any_any"
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 4,
+        "name": "subtract:dec_dec"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 4,
+        "functionAnchor": 5,
+        "name": "and:bool"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 6,
+        "name": "between:any_any_any"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 7,
         "name": "sum:dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 3,
-        "functionAnchor": 5,
+        "functionAnchor": 8,
         "name": "divide:dec_dec"
       }
     }
@@ -97,8 +122,20 @@
                             "input": {
                               "filter": {
                                 "input": {
-                                  "join": {
-                                    "left": {
+                                  "project": {
+                                    "common": {
+                                      "emit": {
+                                        "outputMapping": [
+                                          60,
+                                          61,
+                                          62,
+                                          63,
+                                          64,
+                                          65
+                                        ]
+                                      }
+                                    },
+                                    "input": {
                                       "join": {
                                         "left": {
                                           "join": {
@@ -111,80 +148,244 @@
                                                         "left": {
                                                           "join": {
                                                             "left": {
-                                                              "read": {
-                                                                "common": {
-                                                                  "direct": {}
-                                                                },
-                                                                "baseSchema": {
-                                                                  "names": [
-                                                                    "p_partkey",
-                                                                    "p_name",
-                                                                    "p_mfgr",
-                                                                    "p_brand",
-                                                                    "p_type",
-                                                                    "p_size",
-                                                                    "p_container",
-                                                                    "p_retailprice",
-                                                                    "p_comment"
-                                                                  ],
-                                                                  "struct": {
-                                                                    "types": [
-                                                                      {
-                                                                        "i32": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "i32": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "decimal": {
-                                                                          "scale": 2,
-                                                                          "precision": 15,
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
+                                                              "join": {
+                                                                "left": {
+                                                                  "read": {
+                                                                    "common": {
+                                                                      "direct": {}
+                                                                    },
+                                                                    "baseSchema": {
+                                                                      "names": [
+                                                                        "p_partkey",
+                                                                        "p_name",
+                                                                        "p_mfgr",
+                                                                        "p_brand",
+                                                                        "p_type",
+                                                                        "p_size",
+                                                                        "p_container",
+                                                                        "p_retailprice",
+                                                                        "p_comment"
+                                                                      ],
+                                                                      "struct": {
+                                                                        "types": [
+                                                                          {
+                                                                            "i32": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "i32": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "decimal": {
+                                                                              "scale": 2,
+                                                                              "precision": 15,
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "nullability": "NULLABILITY_REQUIRED"
                                                                       }
-                                                                    ],
-                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                    },
+                                                                    "namedTable": {
+                                                                      "names": [
+                                                                        "part"
+                                                                      ]
+                                                                    }
                                                                   }
                                                                 },
-                                                                "namedTable": {
-                                                                  "names": [
-                                                                    "part"
-                                                                  ]
-                                                                }
+                                                                "right": {
+                                                                  "read": {
+                                                                    "common": {
+                                                                      "direct": {}
+                                                                    },
+                                                                    "baseSchema": {
+                                                                      "names": [
+                                                                        "l_orderkey",
+                                                                        "l_partkey",
+                                                                        "l_suppkey",
+                                                                        "l_linenumber",
+                                                                        "l_quantity",
+                                                                        "l_extendedprice",
+                                                                        "l_discount",
+                                                                        "l_tax",
+                                                                        "l_returnflag",
+                                                                        "l_linestatus",
+                                                                        "l_shipdate",
+                                                                        "l_commitdate",
+                                                                        "l_receiptdate",
+                                                                        "l_shipinstruct",
+                                                                        "l_shipmode",
+                                                                        "l_comment"
+                                                                      ],
+                                                                      "struct": {
+                                                                        "types": [
+                                                                          {
+                                                                            "i64": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "i64": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "i64": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "i64": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "decimal": {
+                                                                              "scale": 2,
+                                                                              "precision": 15,
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "decimal": {
+                                                                              "scale": 2,
+                                                                              "precision": 15,
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "decimal": {
+                                                                              "scale": 2,
+                                                                              "precision": 15,
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "decimal": {
+                                                                              "scale": 2,
+                                                                              "precision": 15,
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "date": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "date": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "date": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          }
+                                                                        ],
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    "namedTable": {
+                                                                      "names": [
+                                                                        "lineitem"
+                                                                      ]
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "expression": {
+                                                                  "scalarFunction": {
+                                                                    "functionReference": 1,
+                                                                    "outputType": {
+                                                                      "bool": {
+                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                      }
+                                                                    },
+                                                                    "arguments": [
+                                                                      {
+                                                                        "value": {
+                                                                          "selection": {
+                                                                            "directReference": {
+                                                                              "structField": {}
+                                                                            },
+                                                                            "rootReference": {}
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "value": {
+                                                                          "selection": {
+                                                                            "directReference": {
+                                                                              "structField": {
+                                                                                "field": 10
+                                                                              }
+                                                                            },
+                                                                            "rootReference": {}
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "JOIN_TYPE_INNER"
                                                               }
                                                             },
                                                             "right": {
@@ -194,111 +395,51 @@
                                                                 },
                                                                 "baseSchema": {
                                                                   "names": [
-                                                                    "l_orderkey",
-                                                                    "l_partkey",
-                                                                    "l_suppkey",
-                                                                    "l_linenumber",
-                                                                    "l_quantity",
-                                                                    "l_extendedprice",
-                                                                    "l_discount",
-                                                                    "l_tax",
-                                                                    "l_returnflag",
-                                                                    "l_linestatus",
-                                                                    "l_shipdate",
-                                                                    "l_commitdate",
-                                                                    "l_receiptdate",
-                                                                    "l_shipinstruct",
-                                                                    "l_shipmode",
-                                                                    "l_comment"
+                                                                    "s_suppkey",
+                                                                    "s_name",
+                                                                    "s_address",
+                                                                    "s_nationkey",
+                                                                    "s_phone",
+                                                                    "s_acctbal",
+                                                                    "s_comment"
                                                                   ],
                                                                   "struct": {
                                                                     "types": [
                                                                       {
-                                                                        "i64": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                        "i32": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       },
                                                                       {
-                                                                        "i64": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                        "string": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       },
                                                                       {
-                                                                        "i64": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                        "string": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       },
                                                                       {
-                                                                        "i64": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                        "i32": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "string": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       },
                                                                       {
                                                                         "decimal": {
                                                                           "scale": 2,
                                                                           "precision": 15,
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "decimal": {
-                                                                          "scale": 2,
-                                                                          "precision": 15,
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "decimal": {
-                                                                          "scale": 2,
-                                                                          "precision": 15,
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "decimal": {
-                                                                          "scale": 2,
-                                                                          "precision": 15,
-                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                          "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       },
                                                                       {
                                                                         "string": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "date": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "date": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "date": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                          "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       }
                                                                     ],
@@ -307,7 +448,7 @@
                                                                 },
                                                                 "namedTable": {
                                                                   "names": [
-                                                                    "lineitem"
+                                                                    "supplier"
                                                                   ]
                                                                 }
                                                               }
@@ -325,7 +466,9 @@
                                                                     "value": {
                                                                       "selection": {
                                                                         "directReference": {
-                                                                          "structField": {}
+                                                                          "structField": {
+                                                                            "field": 25
+                                                                          }
                                                                         },
                                                                         "rootReference": {}
                                                                       }
@@ -336,7 +479,7 @@
                                                                       "selection": {
                                                                         "directReference": {
                                                                           "structField": {
-                                                                            "field": 10
+                                                                            "field": 11
                                                                           }
                                                                         },
                                                                         "rootReference": {}
@@ -356,28 +499,20 @@
                                                             },
                                                             "baseSchema": {
                                                               "names": [
-                                                                "s_suppkey",
-                                                                "s_name",
-                                                                "s_address",
-                                                                "s_nationkey",
-                                                                "s_phone",
-                                                                "s_acctbal",
-                                                                "s_comment"
+                                                                "o_orderkey",
+                                                                "o_custkey",
+                                                                "o_orderstatus",
+                                                                "o_totalprice",
+                                                                "o_orderdate",
+                                                                "o_orderpriority",
+                                                                "o_clerk",
+                                                                "o_shippriority",
+                                                                "o_comment"
                                                               ],
                                                               "struct": {
                                                                 "types": [
                                                                   {
                                                                     "i32": {
-                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "string": {
-                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "string": {
                                                                       "nullability": "NULLABILITY_REQUIRED"
                                                                     }
                                                                   },
@@ -399,6 +534,26 @@
                                                                     }
                                                                   },
                                                                   {
+                                                                    "date": {
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "string": {
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "string": {
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "i32": {
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  {
                                                                     "string": {
                                                                       "nullability": "NULLABILITY_REQUIRED"
                                                                     }
@@ -409,7 +564,7 @@
                                                             },
                                                             "namedTable": {
                                                               "names": [
-                                                                "supplier"
+                                                                "orders"
                                                               ]
                                                             }
                                                           }
@@ -428,7 +583,7 @@
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 25
+                                                                        "field": 9
                                                                       }
                                                                     },
                                                                     "rootReference": {}
@@ -440,7 +595,7 @@
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 11
+                                                                        "field": 32
                                                                       }
                                                                     },
                                                                     "rootReference": {}
@@ -460,20 +615,29 @@
                                                         },
                                                         "baseSchema": {
                                                           "names": [
-                                                            "o_orderkey",
-                                                            "o_custkey",
-                                                            "o_orderstatus",
-                                                            "o_totalprice",
-                                                            "o_orderdate",
-                                                            "o_orderpriority",
-                                                            "o_clerk",
-                                                            "o_shippriority",
-                                                            "o_comment"
+                                                            "c_custkey",
+                                                            "c_name",
+                                                            "c_address",
+                                                            "c_nationkey",
+                                                            "c_phone",
+                                                            "c_acctbal",
+                                                            "c_mktsegment",
+                                                            "c_comment"
                                                           ],
                                                           "struct": {
                                                             "types": [
                                                               {
                                                                 "i32": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              },
+                                                              {
+                                                                "string": {
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              },
+                                                              {
+                                                                "string": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
                                                                 }
                                                               },
@@ -495,22 +659,7 @@
                                                                 }
                                                               },
                                                               {
-                                                                "date": {
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              {
                                                                 "string": {
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              {
-                                                                "string": {
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              {
-                                                                "i32": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
                                                                 }
                                                               },
@@ -525,7 +674,7 @@
                                                         },
                                                         "namedTable": {
                                                           "names": [
-                                                            "orders"
+                                                            "customer"
                                                           ]
                                                         }
                                                       }
@@ -544,7 +693,7 @@
                                                               "selection": {
                                                                 "directReference": {
                                                                   "structField": {
-                                                                    "field": 9
+                                                                    "field": 33
                                                                   }
                                                                 },
                                                                 "rootReference": {}
@@ -556,7 +705,7 @@
                                                               "selection": {
                                                                 "directReference": {
                                                                   "structField": {
-                                                                    "field": 32
+                                                                    "field": 41
                                                                   }
                                                                 },
                                                                 "rootReference": {}
@@ -576,14 +725,10 @@
                                                     },
                                                     "baseSchema": {
                                                       "names": [
-                                                        "c_custkey",
-                                                        "c_name",
-                                                        "c_address",
-                                                        "c_nationkey",
-                                                        "c_phone",
-                                                        "c_acctbal",
-                                                        "c_mktsegment",
-                                                        "c_comment"
+                                                        "n_nationkey",
+                                                        "n_name",
+                                                        "n_regionkey",
+                                                        "n_comment"
                                                       ],
                                                       "struct": {
                                                         "types": [
@@ -598,29 +743,7 @@
                                                             }
                                                           },
                                                           {
-                                                            "string": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          },
-                                                          {
                                                             "i32": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          },
-                                                          {
-                                                            "string": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          },
-                                                          {
-                                                            "decimal": {
-                                                              "scale": 2,
-                                                              "precision": 15,
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          },
-                                                          {
-                                                            "string": {
                                                               "nullability": "NULLABILITY_REQUIRED"
                                                             }
                                                           },
@@ -635,7 +758,7 @@
                                                     },
                                                     "namedTable": {
                                                       "names": [
-                                                        "customer"
+                                                        "nation"
                                                       ]
                                                     }
                                                   }
@@ -654,7 +777,7 @@
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 33
+                                                                "field": 44
                                                               }
                                                             },
                                                             "rootReference": {}
@@ -666,7 +789,7 @@
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 41
+                                                                "field": 49
                                                               }
                                                             },
                                                             "rootReference": {}
@@ -686,10 +809,9 @@
                                                 },
                                                 "baseSchema": {
                                                   "names": [
-                                                    "n_nationkey",
-                                                    "n_name",
-                                                    "n_regionkey",
-                                                    "n_comment"
+                                                    "r_regionkey",
+                                                    "r_name",
+                                                    "r_comment"
                                                   ],
                                                   "struct": {
                                                     "types": [
@@ -704,11 +826,6 @@
                                                         }
                                                       },
                                                       {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
                                                         "string": {
                                                           "nullability": "NULLABILITY_REQUIRED"
                                                         }
@@ -719,7 +836,7 @@
                                                 },
                                                 "namedTable": {
                                                   "names": [
-                                                    "nation"
+                                                    "region"
                                                   ]
                                                 }
                                               }
@@ -738,7 +855,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 44
+                                                            "field": 51
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -750,7 +867,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 49
+                                                            "field": 53
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -770,9 +887,10 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "r_regionkey",
-                                                "r_name",
-                                                "r_comment"
+                                                "n_nationkey",
+                                                "n_name",
+                                                "n_regionkey",
+                                                "n_comment"
                                               ],
                                               "struct": {
                                                 "types": [
@@ -787,6 +905,11 @@
                                                     }
                                                   },
                                                   {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
                                                     "string": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
@@ -797,7 +920,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "region"
+                                                "nation"
                                               ]
                                             }
                                           }
@@ -816,7 +939,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 51
+                                                        "field": 28
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -827,9 +950,7 @@
                                                 "value": {
                                                   "selection": {
                                                     "directReference": {
-                                                      "structField": {
-                                                        "field": 53
-                                                      }
+                                                      "structField": {}
                                                     },
                                                     "rootReference": {}
                                                   }
@@ -841,91 +962,163 @@
                                         "type": "JOIN_TYPE_INNER"
                                       }
                                     },
-                                    "right": {
-                                      "read": {
-                                        "common": {
-                                          "direct": {}
-                                        },
-                                        "baseSchema": {
-                                          "names": [
-                                            "n_nationkey",
-                                            "n_name",
-                                            "n_regionkey",
-                                            "n_comment"
-                                          ],
-                                          "struct": {
-                                            "types": [
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              }
-                                            ],
-                                            "nullability": "NULLABILITY_REQUIRED"
-                                          }
-                                        },
-                                        "namedTable": {
-                                          "names": [
-                                            "nation"
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "expression": {
-                                      "scalarFunction": {
-                                        "functionReference": 1,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 28
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
+                                    "expressions": [
+                                      {
+                                        "cast": {
+                                          "type": {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {}
+                                          "input": {
+                                            "scalarFunction": {
+                                              "functionReference": 2,
+                                              "outputType": {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "enum": "YEAR"
                                                 },
-                                                "rootReference": {}
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 36
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                        }
+                                      },
+                                      {
+                                        "scalarFunction": {
+                                          "functionReference": 3,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 14
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "scalarFunction": {
+                                                  "functionReference": 4,
+                                                  "outputType": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "arguments": [
+                                                    {
+                                                      "value": {
+                                                        "cast": {
+                                                          "type": {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "input": {
+                                                            "literal": {
+                                                              "i8": 1
+                                                            }
+                                                          },
+                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "value": {
+                                                        "selection": {
+                                                          "directReference": {
+                                                            "structField": {
+                                                              "field": 15
+                                                            }
+                                                          },
+                                                          "rootReference": {}
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
                                               }
                                             }
-                                          }
-                                        ]
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 1
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      },
+                                      {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 54
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      },
+                                      {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 36
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      },
+                                      {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 4
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
                                       }
-                                    },
-                                    "type": "JOIN_TYPE_INNER"
+                                    ]
                                   }
                                 },
                                 "condition": {
                                   "scalarFunction": {
-                                    "functionReference": 2,
+                                    "functionReference": 5,
                                     "outputType": {
                                       "bool": {
                                         "nullability": "NULLABILITY_NULLABLE"
@@ -935,7 +1128,7 @@
                                       {
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 2,
+                                            "functionReference": 5,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_NULLABLE"
@@ -978,7 +1171,7 @@
                                               {
                                                 "value": {
                                                   "scalarFunction": {
-                                                    "functionReference": 3,
+                                                    "functionReference": 6,
                                                     "outputType": {
                                                       "bool": {
                                                         "nullability": "NULLABILITY_NULLABLE"
@@ -1190,7 +1383,7 @@
                         "measures": [
                           {
                             "measure": {
-                              "functionReference": 4,
+                              "functionReference": 7,
                               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                               "outputType": {
                                 "decimal": {
@@ -1217,7 +1410,7 @@
                           },
                           {
                             "measure": {
-                              "functionReference": 4,
+                              "functionReference": 7,
                               "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                               "outputType": {
                                 "decimal": {
@@ -1276,7 +1469,7 @@
                       },
                       {
                         "scalarFunction": {
-                          "functionReference": 5,
+                          "functionReference": 8,
                           "outputType": {
                             "fp64": {
                               "nullability": "NULLABILITY_NULLABLE"

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
@@ -10,11 +10,15 @@
     },
     {
       "extensionUriAnchor": 3,
-      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_string.yaml"
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic_decimal.yaml"
     },
     {
       "extensionUriAnchor": 4,
-      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic_decimal.yaml"
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_datetime.yaml"
+    },
+    {
+      "extensionUriAnchor": 5,
+      "uri": "https://github.com/substrait-io/substrait/blob/main/extensions/functions_string.yaml"
     }
   ],
   "extensions": [
@@ -36,13 +40,34 @@
       "extensionFunction": {
         "extensionUriReference": 3,
         "functionAnchor": 3,
-        "name": "like:str_str"
+        "name": "subtract:dec_dec"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 4,
+        "name": "multiply:dec_dec"
       }
     },
     {
       "extensionFunction": {
         "extensionUriReference": 4,
-        "functionAnchor": 4,
+        "functionAnchor": 5,
+        "name": "extract:date"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 5,
+        "functionAnchor": 6,
+        "name": "like:str_str"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 3,
+        "functionAnchor": 7,
         "name": "sum:dec"
       }
     }
@@ -57,8 +82,18 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              50,
+                              51,
+                              52,
+                              53
+                            ]
+                          }
+                        },
+                        "input": {
                           "join": {
                             "left": {
                               "join": {
@@ -67,128 +102,234 @@
                                     "left": {
                                       "join": {
                                         "left": {
-                                          "read": {
-                                            "common": {
-                                              "direct": {}
-                                            },
-                                            "baseSchema": {
-                                              "names": [
-                                                "l_orderkey",
-                                                "l_partkey",
-                                                "l_suppkey",
-                                                "l_linenumber",
-                                                "l_quantity",
-                                                "l_extendedprice",
-                                                "l_discount",
-                                                "l_tax",
-                                                "l_returnflag",
-                                                "l_linestatus",
-                                                "l_shipdate",
-                                                "l_commitdate",
-                                                "l_receiptdate",
-                                                "l_shipinstruct",
-                                                "l_shipmode",
-                                                "l_comment"
-                                              ],
-                                              "struct": {
-                                                "types": [
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
+                                          "join": {
+                                            "left": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "l_orderkey",
+                                                    "l_partkey",
+                                                    "l_suppkey",
+                                                    "l_linenumber",
+                                                    "l_quantity",
+                                                    "l_extendedprice",
+                                                    "l_discount",
+                                                    "l_tax",
+                                                    "l_returnflag",
+                                                    "l_linestatus",
+                                                    "l_shipdate",
+                                                    "l_commitdate",
+                                                    "l_receiptdate",
+                                                    "l_shipinstruct",
+                                                    "l_shipmode",
+                                                    "l_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
                                                   }
-                                                ],
-                                                "nullability": "NULLABILITY_REQUIRED"
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "lineitem"
+                                                  ]
+                                                }
                                               }
                                             },
-                                            "namedTable": {
-                                              "names": [
-                                                "lineitem"
-                                              ]
-                                            }
+                                            "right": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "s_suppkey",
+                                                    "s_name",
+                                                    "s_address",
+                                                    "s_nationkey",
+                                                    "s_phone",
+                                                    "s_acctbal",
+                                                    "s_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                  }
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "supplier"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expression": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 16
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 2
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "JOIN_TYPE_INNER"
                                           }
                                         },
                                         "right": {
@@ -198,13 +339,11 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "s_suppkey",
-                                                "s_name",
-                                                "s_address",
-                                                "s_nationkey",
-                                                "s_phone",
-                                                "s_acctbal",
-                                                "s_comment"
+                                                "ps_partkey",
+                                                "ps_suppkey",
+                                                "ps_availqty",
+                                                "ps_supplycost",
+                                                "ps_comment"
                                               ],
                                               "struct": {
                                                 "types": [
@@ -214,22 +353,12 @@
                                                     }
                                                   },
                                                   {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
                                                     "i32": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "string": {
+                                                    "i32": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
@@ -251,14 +380,14 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "supplier"
+                                                "partsupp"
                                               ]
                                             }
                                           }
                                         },
                                         "expression": {
                                           "scalarFunction": {
-                                            "functionReference": 1,
+                                            "functionReference": 2,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_NULLABLE"
@@ -267,25 +396,77 @@
                                             "arguments": [
                                               {
                                                 "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 16
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
                                                       }
                                                     },
-                                                    "rootReference": {}
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 24
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 2
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
                                                   }
                                                 }
                                               },
                                               {
                                                 "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 2
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
                                                       }
                                                     },
-                                                    "rootReference": {}
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 23
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 1
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
                                                   }
                                                 }
                                               }
@@ -302,11 +483,15 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "ps_partkey",
-                                            "ps_suppkey",
-                                            "ps_availqty",
-                                            "ps_supplycost",
-                                            "ps_comment"
+                                            "p_partkey",
+                                            "p_name",
+                                            "p_mfgr",
+                                            "p_brand",
+                                            "p_type",
+                                            "p_size",
+                                            "p_container",
+                                            "p_retailprice",
+                                            "p_comment"
                                           ],
                                           "struct": {
                                             "types": [
@@ -316,12 +501,32 @@
                                                 }
                                               },
                                               {
-                                                "i32": {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -343,14 +548,14 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "partsupp"
+                                            "part"
                                           ]
                                         }
                                       }
                                     },
                                     "expression": {
                                       "scalarFunction": {
-                                        "functionReference": 2,
+                                        "functionReference": 1,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_NULLABLE"
@@ -359,77 +564,25 @@
                                         "arguments": [
                                           {
                                             "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 1,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 28
                                                   }
                                                 },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 24
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 2
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  }
-                                                ]
+                                                "rootReference": {}
                                               }
                                             }
                                           },
                                           {
                                             "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 1,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 1
                                                   }
                                                 },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 23
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 1
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  }
-                                                ]
+                                                "rootReference": {}
                                               }
                                             }
                                           }
@@ -446,40 +599,20 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "p_partkey",
-                                        "p_name",
-                                        "p_mfgr",
-                                        "p_brand",
-                                        "p_type",
-                                        "p_size",
-                                        "p_container",
-                                        "p_retailprice",
-                                        "p_comment"
+                                        "o_orderkey",
+                                        "o_custkey",
+                                        "o_orderstatus",
+                                        "o_totalprice",
+                                        "o_orderdate",
+                                        "o_orderpriority",
+                                        "o_clerk",
+                                        "o_shippriority",
+                                        "o_comment"
                                       ],
                                       "struct": {
                                         "types": [
                                           {
                                             "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
@@ -501,6 +634,26 @@
                                             }
                                           },
                                           {
+                                            "date": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
                                             "string": {
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
@@ -511,7 +664,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "part"
+                                        "orders"
                                       ]
                                     }
                                   }
@@ -530,7 +683,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 28
+                                                "field": 37
                                               }
                                             },
                                             "rootReference": {}
@@ -541,9 +694,7 @@
                                         "value": {
                                           "selection": {
                                             "directReference": {
-                                              "structField": {
-                                                "field": 1
-                                              }
+                                              "structField": {}
                                             },
                                             "rootReference": {}
                                           }
@@ -562,47 +713,15 @@
                                 },
                                 "baseSchema": {
                                   "names": [
-                                    "o_orderkey",
-                                    "o_custkey",
-                                    "o_orderstatus",
-                                    "o_totalprice",
-                                    "o_orderdate",
-                                    "o_orderpriority",
-                                    "o_clerk",
-                                    "o_shippriority",
-                                    "o_comment"
+                                    "n_nationkey",
+                                    "n_name",
+                                    "n_regionkey",
+                                    "n_comment"
                                   ],
                                   "struct": {
                                     "types": [
                                       {
                                         "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
                                           "nullability": "NULLABILITY_REQUIRED"
                                         }
                                       },
@@ -627,7 +746,7 @@
                                 },
                                 "namedTable": {
                                   "names": [
-                                    "orders"
+                                    "nation"
                                   ]
                                 }
                               }
@@ -646,7 +765,7 @@
                                       "selection": {
                                         "directReference": {
                                           "structField": {
-                                            "field": 37
+                                            "field": 19
                                           }
                                         },
                                         "rootReference": {}
@@ -657,7 +776,9 @@
                                     "value": {
                                       "selection": {
                                         "directReference": {
-                                          "structField": {}
+                                          "structField": {
+                                            "field": 46
+                                          }
                                         },
                                         "rootReference": {}
                                       }
@@ -669,93 +790,211 @@
                             "type": "JOIN_TYPE_INNER"
                           }
                         },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "n_nationkey",
-                                "n_name",
-                                "n_regionkey",
-                                "n_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "nation"
-                              ]
-                            }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 19
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
+                        "expressions": [
+                          {
+                            "scalarFunction": {
+                              "functionReference": 3,
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
                                 }
                               },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 46
-                                      }
-                                    },
-                                    "rootReference": {}
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 4,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 5
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "scalarFunction": {
+                                              "functionReference": 3,
+                                              "outputType": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "cast": {
+                                                      "type": {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "input": {
+                                                        "literal": {
+                                                          "i8": 1
+                                                        }
+                                                      },
+                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 6
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 4,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "cast": {
+                                              "type": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "input": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 26
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              },
+                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 4
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
                                   }
                                 }
-                              }
-                            ]
+                              ]
+                            }
+                          },
+                          {
+                            "cast": {
+                              "type": {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "input": {
+                                "scalarFunction": {
+                                  "functionReference": 5,
+                                  "outputType": {
+                                    "i32": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "enum": "YEAR"
+                                    },
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 41
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 47
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 29
+                                }
+                              },
+                              "rootReference": {}
+                            }
                           }
-                        },
-                        "type": "JOIN_TYPE_INNER"
+                        ]
                       }
                     },
                     "condition": {
                       "scalarFunction": {
-                        "functionReference": 3,
+                        "functionReference": 6,
                         "outputType": {
                           "bool": {
                             "nullability": "NULLABILITY_NULLABLE"
@@ -815,7 +1054,7 @@
                 "measures": [
                   {
                     "measure": {
-                      "functionReference": 4,
+                      "functionReference": 7,
                       "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                       "outputType": {
                         "decimal": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
@@ -76,80 +76,239 @@
                     "input": {
                       "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42,
+                                  43,
+                                  44,
+                                  45,
+                                  46,
+                                  47,
+                                  48,
+                                  49,
+                                  50,
+                                  51,
+                                  52,
+                                  53,
+                                  54,
+                                  55,
+                                  56,
+                                  57,
+                                  58,
+                                  59,
+                                  60,
+                                  61,
+                                  62,
+                                  63,
+                                  64,
+                                  65,
+                                  66,
+                                  67,
+                                  68,
+                                  69,
+                                  70,
+                                  71,
+                                  72,
+                                  73
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
                                   "join": {
                                     "left": {
-                                      "read": {
-                                        "common": {
-                                          "direct": {}
-                                        },
-                                        "baseSchema": {
-                                          "names": [
-                                            "c_custkey",
-                                            "c_name",
-                                            "c_address",
-                                            "c_nationkey",
-                                            "c_phone",
-                                            "c_acctbal",
-                                            "c_mktsegment",
-                                            "c_comment"
-                                          ],
-                                          "struct": {
-                                            "types": [
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
+                                      "join": {
+                                        "left": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "c_custkey",
+                                                "c_name",
+                                                "c_address",
+                                                "c_nationkey",
+                                                "c_phone",
+                                                "c_acctbal",
+                                                "c_mktsegment",
+                                                "c_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
                                               }
-                                            ],
-                                            "nullability": "NULLABILITY_REQUIRED"
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "customer"
+                                              ]
+                                            }
                                           }
                                         },
-                                        "namedTable": {
-                                          "names": [
-                                            "customer"
-                                          ]
-                                        }
+                                        "right": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "o_orderkey",
+                                                "o_custkey",
+                                                "o_orderstatus",
+                                                "o_totalprice",
+                                                "o_orderdate",
+                                                "o_orderpriority",
+                                                "o_clerk",
+                                                "o_shippriority",
+                                                "o_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                              }
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "orders"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "expression": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {}
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 9
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "JOIN_TYPE_INNER"
                                       }
                                     },
                                     "right": {
@@ -159,63 +318,111 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "o_orderkey",
-                                            "o_custkey",
-                                            "o_orderstatus",
-                                            "o_totalprice",
-                                            "o_orderdate",
-                                            "o_orderpriority",
-                                            "o_clerk",
-                                            "o_shippriority",
-                                            "o_comment"
+                                            "l_orderkey",
+                                            "l_partkey",
+                                            "l_suppkey",
+                                            "l_linenumber",
+                                            "l_quantity",
+                                            "l_extendedprice",
+                                            "l_discount",
+                                            "l_tax",
+                                            "l_returnflag",
+                                            "l_linestatus",
+                                            "l_shipdate",
+                                            "l_commitdate",
+                                            "l_receiptdate",
+                                            "l_shipinstruct",
+                                            "l_shipmode",
+                                            "l_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "decimal": {
                                                   "scale": 2,
                                                   "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "date": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               }
                                             ],
@@ -224,7 +431,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "orders"
+                                            "lineitem"
                                           ]
                                         }
                                       }
@@ -242,7 +449,9 @@
                                             "value": {
                                               "selection": {
                                                 "directReference": {
-                                                  "structField": {}
+                                                  "structField": {
+                                                    "field": 17
+                                                  }
                                                 },
                                                 "rootReference": {}
                                               }
@@ -253,7 +462,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 9
+                                                    "field": 8
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -273,111 +482,31 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "l_orderkey",
-                                        "l_partkey",
-                                        "l_suppkey",
-                                        "l_linenumber",
-                                        "l_quantity",
-                                        "l_extendedprice",
-                                        "l_discount",
-                                        "l_tax",
-                                        "l_returnflag",
-                                        "l_linestatus",
-                                        "l_shipdate",
-                                        "l_commitdate",
-                                        "l_receiptdate",
-                                        "l_shipinstruct",
-                                        "l_shipmode",
-                                        "l_comment"
+                                        "n_nationkey",
+                                        "n_name",
+                                        "n_regionkey",
+                                        "n_comment"
                                       ],
                                       "struct": {
                                         "types": [
                                           {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
+                                              "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           }
                                         ],
@@ -386,7 +515,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "lineitem"
+                                        "nation"
                                       ]
                                     }
                                   }
@@ -405,7 +534,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 17
+                                                "field": 3
                                               }
                                             },
                                             "rootReference": {}
@@ -417,7 +546,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 8
+                                                "field": 33
                                               }
                                             },
                                             "rootReference": {}
@@ -430,88 +559,376 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "n_nationkey",
-                                    "n_name",
-                                    "n_regionkey",
-                                    "n_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "nation"
-                                  ]
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
                                 }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 3
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 33
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
                                     }
-                                  }
-                                ]
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 25
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 26
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 27
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 28
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 29
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 30
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 31
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 32
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 33
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 34
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 35
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 36
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
                               }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
                         },
                         "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
@@ -51,60 +51,188 @@
                     "input": {
                       "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  16,
+                                  17,
+                                  18,
+                                  19,
+                                  20,
+                                  21,
+                                  22,
+                                  23,
+                                  24,
+                                  25,
+                                  26,
+                                  27,
+                                  28,
+                                  29,
+                                  30,
+                                  31
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "ps_partkey",
-                                        "ps_suppkey",
-                                        "ps_availqty",
-                                        "ps_supplycost",
-                                        "ps_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
+                                  "join": {
+                                    "left": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "ps_partkey",
+                                            "ps_suppkey",
+                                            "ps_availqty",
+                                            "ps_supplycost",
+                                            "ps_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
                                           }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "partsupp"
+                                          ]
+                                        }
                                       }
                                     },
-                                    "namedTable": {
-                                      "names": [
-                                        "partsupp"
-                                      ]
-                                    }
+                                    "right": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "s_suppkey",
+                                            "s_name",
+                                            "s_address",
+                                            "s_nationkey",
+                                            "s_phone",
+                                            "s_acctbal",
+                                            "s_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                          }
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "supplier"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "expression": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 1
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 5
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "JOIN_TYPE_INNER"
                                   }
                                 },
                                 "right": {
@@ -114,13 +242,10 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "s_suppkey",
-                                        "s_name",
-                                        "s_address",
-                                        "s_nationkey",
-                                        "s_phone",
-                                        "s_acctbal",
-                                        "s_comment"
+                                        "n_nationkey",
+                                        "n_name",
+                                        "n_regionkey",
+                                        "n_comment"
                                       ],
                                       "struct": {
                                         "types": [
@@ -135,24 +260,7 @@
                                             }
                                           },
                                           {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
                                             "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
@@ -167,7 +275,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "supplier"
+                                        "nation"
                                       ]
                                     }
                                   }
@@ -186,7 +294,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 1
+                                                "field": 12
                                               }
                                             },
                                             "rootReference": {}
@@ -198,7 +306,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 5
+                                                "field": 8
                                               }
                                             },
                                             "rootReference": {}
@@ -211,88 +319,166 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "n_nationkey",
-                                    "n_name",
-                                    "n_regionkey",
-                                    "n_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "nation"
-                                  ]
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
                                 }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 12
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 8
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
                                     }
-                                  }
-                                ]
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
                               }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
                         },
                         "condition": {
@@ -455,60 +641,188 @@
                                           "input": {
                                             "filter": {
                                               "input": {
-                                                "join": {
-                                                  "left": {
+                                                "project": {
+                                                  "common": {
+                                                    "emit": {
+                                                      "outputMapping": [
+                                                        16,
+                                                        17,
+                                                        18,
+                                                        19,
+                                                        20,
+                                                        21,
+                                                        22,
+                                                        23,
+                                                        24,
+                                                        25,
+                                                        26,
+                                                        27,
+                                                        28,
+                                                        29,
+                                                        30,
+                                                        31
+                                                      ]
+                                                    }
+                                                  },
+                                                  "input": {
                                                     "join": {
                                                       "left": {
-                                                        "read": {
-                                                          "common": {
-                                                            "direct": {}
-                                                          },
-                                                          "baseSchema": {
-                                                            "names": [
-                                                              "ps_partkey",
-                                                              "ps_suppkey",
-                                                              "ps_availqty",
-                                                              "ps_supplycost",
-                                                              "ps_comment"
-                                                            ],
-                                                            "struct": {
-                                                              "types": [
-                                                                {
-                                                                  "i32": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "i32": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "i32": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "decimal": {
-                                                                    "scale": 2,
-                                                                    "precision": 15,
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
+                                                        "join": {
+                                                          "left": {
+                                                            "read": {
+                                                              "common": {
+                                                                "direct": {}
+                                                              },
+                                                              "baseSchema": {
+                                                                "names": [
+                                                                  "ps_partkey",
+                                                                  "ps_suppkey",
+                                                                  "ps_availqty",
+                                                                  "ps_supplycost",
+                                                                  "ps_comment"
+                                                                ],
+                                                                "struct": {
+                                                                  "types": [
+                                                                    {
+                                                                      "i32": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "i32": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "i32": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "decimal": {
+                                                                        "scale": 2,
+                                                                        "precision": 15,
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "string": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    }
+                                                                  ],
+                                                                  "nullability": "NULLABILITY_REQUIRED"
                                                                 }
-                                                              ],
-                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                              },
+                                                              "namedTable": {
+                                                                "names": [
+                                                                  "partsupp"
+                                                                ]
+                                                              }
                                                             }
                                                           },
-                                                          "namedTable": {
-                                                            "names": [
-                                                              "partsupp"
-                                                            ]
-                                                          }
+                                                          "right": {
+                                                            "read": {
+                                                              "common": {
+                                                                "direct": {}
+                                                              },
+                                                              "baseSchema": {
+                                                                "names": [
+                                                                  "s_suppkey",
+                                                                  "s_name",
+                                                                  "s_address",
+                                                                  "s_nationkey",
+                                                                  "s_phone",
+                                                                  "s_acctbal",
+                                                                  "s_comment"
+                                                                ],
+                                                                "struct": {
+                                                                  "types": [
+                                                                    {
+                                                                      "i32": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "string": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "string": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "i32": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "string": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "decimal": {
+                                                                        "scale": 2,
+                                                                        "precision": 15,
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "string": {
+                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                      }
+                                                                    }
+                                                                  ],
+                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                }
+                                                              },
+                                                              "namedTable": {
+                                                                "names": [
+                                                                  "supplier"
+                                                                ]
+                                                              }
+                                                            }
+                                                          },
+                                                          "expression": {
+                                                            "scalarFunction": {
+                                                              "functionReference": 1,
+                                                              "outputType": {
+                                                                "bool": {
+                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                              },
+                                                              "arguments": [
+                                                                {
+                                                                  "value": {
+                                                                    "selection": {
+                                                                      "directReference": {
+                                                                        "structField": {
+                                                                          "field": 1
+                                                                        }
+                                                                      },
+                                                                      "rootReference": {}
+                                                                    }
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "value": {
+                                                                    "selection": {
+                                                                      "directReference": {
+                                                                        "structField": {
+                                                                          "field": 5
+                                                                        }
+                                                                      },
+                                                                      "rootReference": {}
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "JOIN_TYPE_INNER"
                                                         }
                                                       },
                                                       "right": {
@@ -518,13 +832,10 @@
                                                           },
                                                           "baseSchema": {
                                                             "names": [
-                                                              "s_suppkey",
-                                                              "s_name",
-                                                              "s_address",
-                                                              "s_nationkey",
-                                                              "s_phone",
-                                                              "s_acctbal",
-                                                              "s_comment"
+                                                              "n_nationkey",
+                                                              "n_name",
+                                                              "n_regionkey",
+                                                              "n_comment"
                                                             ],
                                                             "struct": {
                                                               "types": [
@@ -539,24 +850,7 @@
                                                                   }
                                                                 },
                                                                 {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
                                                                   "i32": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "decimal": {
-                                                                    "scale": 2,
-                                                                    "precision": 15,
                                                                     "nullability": "NULLABILITY_REQUIRED"
                                                                   }
                                                                 },
@@ -571,7 +865,7 @@
                                                           },
                                                           "namedTable": {
                                                             "names": [
-                                                              "supplier"
+                                                              "nation"
                                                             ]
                                                           }
                                                         }
@@ -590,7 +884,7 @@
                                                                 "selection": {
                                                                   "directReference": {
                                                                     "structField": {
-                                                                      "field": 1
+                                                                      "field": 12
                                                                     }
                                                                   },
                                                                   "rootReference": {}
@@ -602,7 +896,7 @@
                                                                 "selection": {
                                                                   "directReference": {
                                                                     "structField": {
-                                                                      "field": 5
+                                                                      "field": 8
                                                                     }
                                                                   },
                                                                   "rootReference": {}
@@ -615,88 +909,166 @@
                                                       "type": "JOIN_TYPE_INNER"
                                                     }
                                                   },
-                                                  "right": {
-                                                    "read": {
-                                                      "common": {
-                                                        "direct": {}
-                                                      },
-                                                      "baseSchema": {
-                                                        "names": [
-                                                          "n_nationkey",
-                                                          "n_name",
-                                                          "n_regionkey",
-                                                          "n_comment"
-                                                        ],
-                                                        "struct": {
-                                                          "types": [
-                                                            {
-                                                              "i32": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i32": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            }
-                                                          ],
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      "namedTable": {
-                                                        "names": [
-                                                          "nation"
-                                                        ]
+                                                  "expressions": [
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
+                                                        },
+                                                        "rootReference": {}
                                                       }
-                                                    }
-                                                  },
-                                                  "expression": {
-                                                    "scalarFunction": {
-                                                      "functionReference": 1,
-                                                      "outputType": {
-                                                        "bool": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "arguments": [
-                                                        {
-                                                          "value": {
-                                                            "selection": {
-                                                              "directReference": {
-                                                                "structField": {
-                                                                  "field": 12
-                                                                }
-                                                              },
-                                                              "rootReference": {}
-                                                            }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 1
                                                           }
                                                         },
-                                                        {
-                                                          "value": {
-                                                            "selection": {
-                                                              "directReference": {
-                                                                "structField": {
-                                                                  "field": 8
-                                                                }
-                                                              },
-                                                              "rootReference": {}
-                                                            }
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 2
                                                           }
-                                                        }
-                                                      ]
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 3
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 4
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 5
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 6
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 7
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 8
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 9
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 10
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 11
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 12
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 13
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 14
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    },
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 15
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
                                                     }
-                                                  },
-                                                  "type": "JOIN_TYPE_INNER"
+                                                  ]
                                                 }
                                               },
                                               "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
@@ -60,244 +60,529 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "o_orderkey",
-                                "o_custkey",
-                                "o_orderstatus",
-                                "o_totalprice",
-                                "o_orderdate",
-                                "o_orderpriority",
-                                "o_clerk",
-                                "o_shippriority",
-                                "o_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "orders"
-                              ]
-                            }
-                          }
-                        },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "l_orderkey",
-                                "l_partkey",
-                                "l_suppkey",
-                                "l_linenumber",
-                                "l_quantity",
-                                "l_extendedprice",
-                                "l_discount",
-                                "l_tax",
-                                "l_returnflag",
-                                "l_linestatus",
-                                "l_shipdate",
-                                "l_commitdate",
-                                "l_receiptdate",
-                                "l_shipinstruct",
-                                "l_shipmode",
-                                "l_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "lineitem"
-                              ]
-                            }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {}
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 9
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              }
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              25,
+                              26,
+                              27,
+                              28,
+                              29,
+                              30,
+                              31,
+                              32,
+                              33,
+                              34,
+                              35,
+                              36,
+                              37,
+                              38,
+                              39,
+                              40,
+                              41,
+                              42,
+                              43,
+                              44,
+                              45,
+                              46,
+                              47,
+                              48,
+                              49
                             ]
                           }
                         },
-                        "type": "JOIN_TYPE_INNER"
+                        "input": {
+                          "join": {
+                            "left": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "o_orderkey",
+                                    "o_custkey",
+                                    "o_orderstatus",
+                                    "o_totalprice",
+                                    "o_orderdate",
+                                    "o_orderpriority",
+                                    "o_clerk",
+                                    "o_shippriority",
+                                    "o_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "orders"
+                                  ]
+                                }
+                              }
+                            },
+                            "right": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "l_orderkey",
+                                    "l_partkey",
+                                    "l_suppkey",
+                                    "l_linenumber",
+                                    "l_quantity",
+                                    "l_extendedprice",
+                                    "l_discount",
+                                    "l_tax",
+                                    "l_returnflag",
+                                    "l_linestatus",
+                                    "l_shipdate",
+                                    "l_commitdate",
+                                    "l_receiptdate",
+                                    "l_shipinstruct",
+                                    "l_shipmode",
+                                    "l_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "lineitem"
+                                  ]
+                                }
+                              }
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {}
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 9
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "JOIN_TYPE_INNER"
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 11
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 14
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 15
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 16
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 17
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 18
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 19
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 20
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 21
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 22
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 23
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 24
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          }
+                        ]
                       }
                     },
                     "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
@@ -64,251 +64,448 @@
                 "input": {
                   "aggregate": {
                     "input": {
-                      "join": {
-                        "left": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "c_custkey",
-                                "c_name",
-                                "c_address",
-                                "c_nationkey",
-                                "c_phone",
-                                "c_acctbal",
-                                "c_mktsegment",
-                                "c_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "customer"
-                              ]
-                            }
-                          }
-                        },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "o_orderkey",
-                                "o_custkey",
-                                "o_orderstatus",
-                                "o_totalprice",
-                                "o_orderdate",
-                                "o_orderpriority",
-                                "o_clerk",
-                                "o_shippriority",
-                                "o_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "orders"
-                              ]
-                            }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 2,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {}
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 9
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 3,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 4,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 16
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "%special%requests%"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              }
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              17,
+                              18,
+                              19,
+                              20,
+                              21,
+                              22,
+                              23,
+                              24,
+                              25,
+                              26,
+                              27,
+                              28,
+                              29,
+                              30,
+                              31,
+                              32,
+                              33
                             ]
                           }
                         },
-                        "type": "JOIN_TYPE_LEFT"
+                        "input": {
+                          "join": {
+                            "left": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "c_custkey",
+                                    "c_name",
+                                    "c_address",
+                                    "c_nationkey",
+                                    "c_phone",
+                                    "c_acctbal",
+                                    "c_mktsegment",
+                                    "c_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "customer"
+                                  ]
+                                }
+                              }
+                            },
+                            "right": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "o_orderkey",
+                                    "o_custkey",
+                                    "o_orderstatus",
+                                    "o_totalprice",
+                                    "o_orderdate",
+                                    "o_orderpriority",
+                                    "o_clerk",
+                                    "o_shippriority",
+                                    "o_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "orders"
+                                  ]
+                                }
+                              }
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 2,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {}
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 9
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 3,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 4,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 16
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "%special%requests%"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "JOIN_TYPE_LEFT"
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 11
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 14
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 15
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 16
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          }
+                        ]
                       }
                     },
                     "groupings": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h14/tpc_h14.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h14/tpc_h14.json
@@ -110,246 +110,531 @@
                     "input": {
                       "filter": {
                         "input": {
-                          "join": {
-                            "left": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "l_orderkey",
-                                    "l_partkey",
-                                    "l_suppkey",
-                                    "l_linenumber",
-                                    "l_quantity",
-                                    "l_extendedprice",
-                                    "l_discount",
-                                    "l_tax",
-                                    "l_returnflag",
-                                    "l_linestatus",
-                                    "l_shipdate",
-                                    "l_commitdate",
-                                    "l_receiptdate",
-                                    "l_shipinstruct",
-                                    "l_shipmode",
-                                    "l_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "lineitem"
-                                  ]
-                                }
-                              }
-                            },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "p_partkey",
-                                    "p_name",
-                                    "p_mfgr",
-                                    "p_brand",
-                                    "p_type",
-                                    "p_size",
-                                    "p_container",
-                                    "p_retailprice",
-                                    "p_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "part"
-                                  ]
-                                }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 1
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 16
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  }
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  25,
+                                  26,
+                                  27,
+                                  28,
+                                  29,
+                                  30,
+                                  31,
+                                  32,
+                                  33,
+                                  34,
+                                  35,
+                                  36,
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42,
+                                  43,
+                                  44,
+                                  45,
+                                  46,
+                                  47,
+                                  48,
+                                  49
                                 ]
                               }
                             },
-                            "type": "JOIN_TYPE_INNER"
+                            "input": {
+                              "join": {
+                                "left": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "l_orderkey",
+                                        "l_partkey",
+                                        "l_suppkey",
+                                        "l_linenumber",
+                                        "l_quantity",
+                                        "l_extendedprice",
+                                        "l_discount",
+                                        "l_tax",
+                                        "l_returnflag",
+                                        "l_linestatus",
+                                        "l_shipdate",
+                                        "l_commitdate",
+                                        "l_receiptdate",
+                                        "l_shipinstruct",
+                                        "l_shipmode",
+                                        "l_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "lineitem"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "right": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "p_partkey",
+                                        "p_name",
+                                        "p_mfgr",
+                                        "p_brand",
+                                        "p_type",
+                                        "p_size",
+                                        "p_container",
+                                        "p_retailprice",
+                                        "p_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "part"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "expression": {
+                                  "scalarFunction": {
+                                    "functionReference": 1,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 16
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "JOIN_TYPE_INNER"
+                              }
+                            },
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            ]
                           }
                         },
                         "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h15/tpc_h15.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h15/tpc_h15.json
@@ -92,426 +92,535 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "s_suppkey",
-                                "s_name",
-                                "s_address",
-                                "s_nationkey",
-                                "s_phone",
-                                "s_acctbal",
-                                "s_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "supplier"
-                              ]
-                            }
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              9,
+                              10,
+                              11,
+                              12,
+                              13,
+                              14,
+                              15,
+                              16,
+                              17
+                            ]
                           }
                         },
-                        "right": {
-                          "aggregate": {
-                            "input": {
-                              "filter": {
-                                "input": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "l_orderkey",
-                                        "l_partkey",
-                                        "l_suppkey",
-                                        "l_linenumber",
-                                        "l_quantity",
-                                        "l_extendedprice",
-                                        "l_discount",
-                                        "l_tax",
-                                        "l_returnflag",
-                                        "l_linestatus",
-                                        "l_shipdate",
-                                        "l_commitdate",
-                                        "l_receiptdate",
-                                        "l_shipinstruct",
-                                        "l_shipmode",
-                                        "l_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "lineitem"
-                                      ]
-                                    }
-                                  }
+                        "input": {
+                          "join": {
+                            "left": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
                                 },
-                                "condition": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
+                                "baseSchema": {
+                                  "names": [
+                                    "s_suppkey",
+                                    "s_name",
+                                    "s_address",
+                                    "s_nationkey",
+                                    "s_phone",
+                                    "s_acctbal",
+                                    "s_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
                                       {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 2,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 10
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "1996-01-01"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
                                         }
                                       },
                                       {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "supplier"
+                                  ]
+                                }
+                              }
+                            },
+                            "right": {
+                              "aggregate": {
+                                "input": {
+                                  "filter": {
+                                    "input": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "l_orderkey",
+                                            "l_partkey",
+                                            "l_suppkey",
+                                            "l_linenumber",
+                                            "l_quantity",
+                                            "l_extendedprice",
+                                            "l_discount",
+                                            "l_tax",
+                                            "l_returnflag",
+                                            "l_linestatus",
+                                            "l_shipdate",
+                                            "l_commitdate",
+                                            "l_receiptdate",
+                                            "l_shipinstruct",
+                                            "l_shipmode",
+                                            "l_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
                                               {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 10
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "1996-04-01"
-                                                  }
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               }
-                                            ]
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
                                           }
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "lineitem"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "condition": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 2,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 10
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "1996-01-01"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 10
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "1996-04-01"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                },
+                                "groupings": [
+                                  {
+                                    "groupingExpressions": [
+                                      {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 2
+                                            }
+                                          },
+                                          "rootReference": {}
                                         }
                                       }
                                     ]
                                   }
-                                }
-                              }
-                            },
-                            "groupings": [
-                              {
-                                "groupingExpressions": [
+                                ],
+                                "measures": [
                                   {
-                                    "selection": {
-                                      "directReference": {
-                                        "structField": {
-                                          "field": 2
+                                    "measure": {
+                                      "functionReference": 4,
+                                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 38,
+                                          "nullability": "NULLABILITY_NULLABLE"
                                         }
                                       },
-                                      "rootReference": {}
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "scalarFunction": {
+                                              "functionReference": 5,
+                                              "outputType": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 5
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "scalarFunction": {
+                                                      "functionReference": 6,
+                                                      "outputType": {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "arguments": [
+                                                        {
+                                                          "value": {
+                                                            "cast": {
+                                                              "type": {
+                                                                "decimal": {
+                                                                  "scale": 2,
+                                                                  "precision": 15,
+                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                              },
+                                                              "input": {
+                                                                "literal": {
+                                                                  "i8": 1
+                                                                }
+                                                              },
+                                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 6
+                                                                }
+                                                              },
+                                                              "rootReference": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
                                     }
                                   }
                                 ]
                               }
-                            ],
-                            "measures": [
-                              {
-                                "measure": {
-                                  "functionReference": 4,
-                                  "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                  "outputType": {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 38,
-                                      "nullability": "NULLABILITY_NULLABLE"
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 7,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {}
+                                        },
+                                        "rootReference": {}
+                                      }
                                     }
                                   },
-                                  "arguments": [
-                                    {
-                                      "value": {
-                                        "scalarFunction": {
-                                          "functionReference": 5,
-                                          "outputType": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 5
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "value": {
-                                                "scalarFunction": {
-                                                  "functionReference": 6,
-                                                  "outputType": {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  "arguments": [
-                                                    {
-                                                      "value": {
-                                                        "cast": {
-                                                          "type": {
-                                                            "decimal": {
-                                                              "scale": 2,
-                                                              "precision": 15,
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "input": {
-                                                            "literal": {
-                                                              "i8": 1
-                                                            }
-                                                          },
-                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                        }
-                                                      }
-                                                    },
-                                                    {
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 6
-                                                            }
-                                                          },
-                                                          "rootReference": {}
-                                                        }
-                                                      }
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 7
+                                          }
+                                        },
+                                        "rootReference": {}
                                       }
                                     }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 7,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                ]
                               }
                             },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {}
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 7
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              }
-                            ]
+                            "type": "JOIN_TYPE_INNER"
                           }
                         },
-                        "type": "JOIN_TYPE_INNER"
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          }
+                        ]
                       }
                     },
                     "condition": {
@@ -542,426 +651,535 @@
                                   "input": {
                                     "aggregate": {
                                       "input": {
-                                        "join": {
-                                          "left": {
-                                            "read": {
-                                              "common": {
-                                                "direct": {}
-                                              },
-                                              "baseSchema": {
-                                                "names": [
-                                                  "s_suppkey",
-                                                  "s_name",
-                                                  "s_address",
-                                                  "s_nationkey",
-                                                  "s_phone",
-                                                  "s_acctbal",
-                                                  "s_comment"
-                                                ],
-                                                "struct": {
-                                                  "types": [
-                                                    {
-                                                      "i32": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    {
-                                                      "i32": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    {
-                                                      "decimal": {
-                                                        "scale": 2,
-                                                        "precision": 15,
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                      }
-                                                    }
-                                                  ],
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "namedTable": {
-                                                "names": [
-                                                  "supplier"
-                                                ]
-                                              }
+                                        "project": {
+                                          "common": {
+                                            "emit": {
+                                              "outputMapping": [
+                                                9,
+                                                10,
+                                                11,
+                                                12,
+                                                13,
+                                                14,
+                                                15,
+                                                16,
+                                                17
+                                              ]
                                             }
                                           },
-                                          "right": {
-                                            "aggregate": {
-                                              "input": {
-                                                "filter": {
-                                                  "input": {
-                                                    "read": {
-                                                      "common": {
-                                                        "direct": {}
-                                                      },
-                                                      "baseSchema": {
-                                                        "names": [
-                                                          "l_orderkey",
-                                                          "l_partkey",
-                                                          "l_suppkey",
-                                                          "l_linenumber",
-                                                          "l_quantity",
-                                                          "l_extendedprice",
-                                                          "l_discount",
-                                                          "l_tax",
-                                                          "l_returnflag",
-                                                          "l_linestatus",
-                                                          "l_shipdate",
-                                                          "l_commitdate",
-                                                          "l_receiptdate",
-                                                          "l_shipinstruct",
-                                                          "l_shipmode",
-                                                          "l_comment"
-                                                        ],
-                                                        "struct": {
-                                                          "types": [
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            }
-                                                          ],
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      "namedTable": {
-                                                        "names": [
-                                                          "lineitem"
-                                                        ]
-                                                      }
-                                                    }
+                                          "input": {
+                                            "join": {
+                                              "left": {
+                                                "read": {
+                                                  "common": {
+                                                    "direct": {}
                                                   },
-                                                  "condition": {
-                                                    "scalarFunction": {
-                                                      "functionReference": 1,
-                                                      "outputType": {
-                                                        "bool": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "arguments": [
+                                                  "baseSchema": {
+                                                    "names": [
+                                                      "s_suppkey",
+                                                      "s_name",
+                                                      "s_address",
+                                                      "s_nationkey",
+                                                      "s_phone",
+                                                      "s_acctbal",
+                                                      "s_comment"
+                                                    ],
+                                                    "struct": {
+                                                      "types": [
                                                         {
-                                                          "value": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 2,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 10
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "value": {
-                                                                    "literal": {
-                                                                      "string": "1996-01-01"
-                                                                    }
-                                                                  }
-                                                                }
-                                                              ]
-                                                            }
+                                                          "i32": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
                                                           }
                                                         },
                                                         {
-                                                          "value": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 3,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
+                                                          "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        {
+                                                          "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        {
+                                                          "i32": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        {
+                                                          "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        {
+                                                          "decimal": {
+                                                            "scale": 2,
+                                                            "precision": 15,
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        },
+                                                        {
+                                                          "string": {
+                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                          }
+                                                        }
+                                                      ],
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  "namedTable": {
+                                                    "names": [
+                                                      "supplier"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "right": {
+                                                "aggregate": {
+                                                  "input": {
+                                                    "filter": {
+                                                      "input": {
+                                                        "read": {
+                                                          "common": {
+                                                            "direct": {}
+                                                          },
+                                                          "baseSchema": {
+                                                            "names": [
+                                                              "l_orderkey",
+                                                              "l_partkey",
+                                                              "l_suppkey",
+                                                              "l_linenumber",
+                                                              "l_quantity",
+                                                              "l_extendedprice",
+                                                              "l_discount",
+                                                              "l_tax",
+                                                              "l_returnflag",
+                                                              "l_linestatus",
+                                                              "l_shipdate",
+                                                              "l_commitdate",
+                                                              "l_receiptdate",
+                                                              "l_shipinstruct",
+                                                              "l_shipmode",
+                                                              "l_comment"
+                                                            ],
+                                                            "struct": {
+                                                              "types": [
                                                                 {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 10
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
                                                                   }
                                                                 },
                                                                 {
-                                                                  "value": {
-                                                                    "literal": {
-                                                                      "string": "1996-04-01"
-                                                                    }
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
                                                                   }
                                                                 }
-                                                              ]
+                                                              ],
+                                                              "nullability": "NULLABILITY_REQUIRED"
                                                             }
+                                                          },
+                                                          "namedTable": {
+                                                            "names": [
+                                                              "lineitem"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "condition": {
+                                                        "scalarFunction": {
+                                                          "functionReference": 1,
+                                                          "outputType": {
+                                                            "bool": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "arguments": [
+                                                            {
+                                                              "value": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 2,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 10
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "literal": {
+                                                                          "string": "1996-01-01"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "value": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 3,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 10
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "literal": {
+                                                                          "string": "1996-04-01"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "groupings": [
+                                                    {
+                                                      "groupingExpressions": [
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 2
+                                                              }
+                                                            },
+                                                            "rootReference": {}
                                                           }
                                                         }
                                                       ]
                                                     }
-                                                  }
-                                                }
-                                              },
-                                              "groupings": [
-                                                {
-                                                  "groupingExpressions": [
+                                                  ],
+                                                  "measures": [
                                                     {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 2
+                                                      "measure": {
+                                                        "functionReference": 4,
+                                                        "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                        "outputType": {
+                                                          "decimal": {
+                                                            "scale": 2,
+                                                            "precision": 38,
+                                                            "nullability": "NULLABILITY_NULLABLE"
                                                           }
                                                         },
-                                                        "rootReference": {}
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 5,
+                                                                "outputType": {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 5
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 6,
+                                                                        "outputType": {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "cast": {
+                                                                                "type": {
+                                                                                  "decimal": {
+                                                                                    "scale": 2,
+                                                                                    "precision": 15,
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                  }
+                                                                                },
+                                                                                "input": {
+                                                                                  "literal": {
+                                                                                    "i8": 1
+                                                                                  }
+                                                                                },
+                                                                                "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "selection": {
+                                                                                "directReference": {
+                                                                                  "structField": {
+                                                                                    "field": 6
+                                                                                  }
+                                                                                },
+                                                                                "rootReference": {}
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
                                                       }
                                                     }
                                                   ]
                                                 }
-                                              ],
-                                              "measures": [
-                                                {
-                                                  "measure": {
-                                                    "functionReference": 4,
-                                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                    "outputType": {
-                                                      "decimal": {
-                                                        "scale": 2,
-                                                        "precision": 38,
-                                                        "nullability": "NULLABILITY_NULLABLE"
+                                              },
+                                              "expression": {
+                                                "scalarFunction": {
+                                                  "functionReference": 7,
+                                                  "outputType": {
+                                                    "bool": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "arguments": [
+                                                    {
+                                                      "value": {
+                                                        "selection": {
+                                                          "directReference": {
+                                                            "structField": {}
+                                                          },
+                                                          "rootReference": {}
+                                                        }
                                                       }
                                                     },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 5,
-                                                            "outputType": {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 5
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "scalarFunction": {
-                                                                    "functionReference": 6,
-                                                                    "outputType": {
-                                                                      "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    "arguments": [
-                                                                      {
-                                                                        "value": {
-                                                                          "cast": {
-                                                                            "type": {
-                                                                              "decimal": {
-                                                                                "scale": 2,
-                                                                                "precision": 15,
-                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                              }
-                                                                            },
-                                                                            "input": {
-                                                                              "literal": {
-                                                                                "i8": 1
-                                                                              }
-                                                                            },
-                                                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "value": {
-                                                                          "selection": {
-                                                                            "directReference": {
-                                                                              "structField": {
-                                                                                "field": 6
-                                                                              }
-                                                                            },
-                                                                            "rootReference": {}
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
+                                                    {
+                                                      "value": {
+                                                        "selection": {
+                                                          "directReference": {
+                                                            "structField": {
+                                                              "field": 7
+                                                            }
+                                                          },
+                                                          "rootReference": {}
                                                         }
                                                       }
-                                                    ]
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          "expression": {
-                                            "scalarFunction": {
-                                              "functionReference": 7,
-                                              "outputType": {
-                                                "bool": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  ]
                                                 }
                                               },
-                                              "arguments": [
-                                                {
-                                                  "value": {
-                                                    "selection": {
-                                                      "directReference": {
-                                                        "structField": {}
-                                                      },
-                                                      "rootReference": {}
-                                                    }
-                                                  }
-                                                },
-                                                {
-                                                  "value": {
-                                                    "selection": {
-                                                      "directReference": {
-                                                        "structField": {
-                                                          "field": 7
-                                                        }
-                                                      },
-                                                      "rootReference": {}
-                                                    }
-                                                  }
-                                                }
-                                              ]
+                                              "type": "JOIN_TYPE_INNER"
                                             }
                                           },
-                                          "type": "JOIN_TYPE_INNER"
+                                          "expressions": [
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {}
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 1
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 2
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 3
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 4
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 5
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 6
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 7
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 8
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          ]
                                         }
                                       },
                                       "groupings": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h16/tpc_h16.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h16/tpc_h16.json
@@ -71,172 +71,336 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "ps_partkey",
-                                "ps_suppkey",
-                                "ps_availqty",
-                                "ps_supplycost",
-                                "ps_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "partsupp"
-                              ]
-                            }
-                          }
-                        },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "p_partkey",
-                                "p_name",
-                                "p_mfgr",
-                                "p_brand",
-                                "p_type",
-                                "p_size",
-                                "p_container",
-                                "p_retailprice",
-                                "p_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "part"
-                              ]
-                            }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 5
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {}
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              }
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              14,
+                              15,
+                              16,
+                              17,
+                              18,
+                              19,
+                              20,
+                              21,
+                              22,
+                              23,
+                              24,
+                              25,
+                              26,
+                              27
                             ]
                           }
                         },
-                        "type": "JOIN_TYPE_INNER"
+                        "input": {
+                          "join": {
+                            "left": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "ps_partkey",
+                                    "ps_suppkey",
+                                    "ps_availqty",
+                                    "ps_supplycost",
+                                    "ps_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "partsupp"
+                                  ]
+                                }
+                              }
+                            },
+                            "right": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "p_partkey",
+                                    "p_name",
+                                    "p_mfgr",
+                                    "p_brand",
+                                    "p_type",
+                                    "p_size",
+                                    "p_container",
+                                    "p_retailprice",
+                                    "p_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "part"
+                                  ]
+                                }
+                              }
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 5
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {}
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "JOIN_TYPE_INNER"
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 11
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          }
+                        ]
                       }
                     },
                     "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h17/tpc_h17.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h17/tpc_h17.json
@@ -81,246 +81,531 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "l_orderkey",
-                                "l_partkey",
-                                "l_suppkey",
-                                "l_linenumber",
-                                "l_quantity",
-                                "l_extendedprice",
-                                "l_discount",
-                                "l_tax",
-                                "l_returnflag",
-                                "l_linestatus",
-                                "l_shipdate",
-                                "l_commitdate",
-                                "l_receiptdate",
-                                "l_shipinstruct",
-                                "l_shipmode",
-                                "l_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "lineitem"
-                              ]
-                            }
-                          }
-                        },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "p_partkey",
-                                "p_name",
-                                "p_mfgr",
-                                "p_brand",
-                                "p_type",
-                                "p_size",
-                                "p_container",
-                                "p_retailprice",
-                                "p_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "part"
-                              ]
-                            }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 16
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 1
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              }
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              25,
+                              26,
+                              27,
+                              28,
+                              29,
+                              30,
+                              31,
+                              32,
+                              33,
+                              34,
+                              35,
+                              36,
+                              37,
+                              38,
+                              39,
+                              40,
+                              41,
+                              42,
+                              43,
+                              44,
+                              45,
+                              46,
+                              47,
+                              48,
+                              49
                             ]
                           }
                         },
-                        "type": "JOIN_TYPE_INNER"
+                        "input": {
+                          "join": {
+                            "left": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "l_orderkey",
+                                    "l_partkey",
+                                    "l_suppkey",
+                                    "l_linenumber",
+                                    "l_quantity",
+                                    "l_extendedprice",
+                                    "l_discount",
+                                    "l_tax",
+                                    "l_returnflag",
+                                    "l_linestatus",
+                                    "l_shipdate",
+                                    "l_commitdate",
+                                    "l_receiptdate",
+                                    "l_shipinstruct",
+                                    "l_shipmode",
+                                    "l_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "lineitem"
+                                  ]
+                                }
+                              }
+                            },
+                            "right": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "p_partkey",
+                                    "p_name",
+                                    "p_mfgr",
+                                    "p_brand",
+                                    "p_type",
+                                    "p_size",
+                                    "p_container",
+                                    "p_retailprice",
+                                    "p_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "part"
+                                  ]
+                                }
+                              }
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 16
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 1
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "JOIN_TYPE_INNER"
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 11
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 14
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 15
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 16
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 17
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 18
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 19
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 20
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 21
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 22
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 23
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 24
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          }
+                        ]
                       }
                     },
                     "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
@@ -44,78 +44,233 @@
                     "input": {
                       "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  33,
+                                  34,
+                                  35,
+                                  36,
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42,
+                                  43,
+                                  44,
+                                  45,
+                                  46,
+                                  47,
+                                  48,
+                                  49,
+                                  50,
+                                  51,
+                                  52,
+                                  53,
+                                  54,
+                                  55,
+                                  56,
+                                  57,
+                                  58,
+                                  59,
+                                  60,
+                                  61,
+                                  62,
+                                  63,
+                                  64,
+                                  65
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "c_custkey",
-                                        "c_name",
-                                        "c_address",
-                                        "c_nationkey",
-                                        "c_phone",
-                                        "c_acctbal",
-                                        "c_mktsegment",
-                                        "c_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
+                                  "join": {
+                                    "left": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "c_custkey",
+                                            "c_name",
+                                            "c_address",
+                                            "c_nationkey",
+                                            "c_phone",
+                                            "c_acctbal",
+                                            "c_mktsegment",
+                                            "c_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
                                           }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "customer"
+                                          ]
+                                        }
                                       }
                                     },
-                                    "namedTable": {
-                                      "names": [
-                                        "customer"
-                                      ]
-                                    }
+                                    "right": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "o_orderkey",
+                                            "o_custkey",
+                                            "o_orderstatus",
+                                            "o_totalprice",
+                                            "o_orderdate",
+                                            "o_orderpriority",
+                                            "o_clerk",
+                                            "o_shippriority",
+                                            "o_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                          }
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "orders"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "expression": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {}
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 9
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "JOIN_TYPE_INNER"
                                   }
                                 },
                                 "right": {
@@ -125,63 +280,111 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "o_orderkey",
-                                        "o_custkey",
-                                        "o_orderstatus",
-                                        "o_totalprice",
-                                        "o_orderdate",
-                                        "o_orderpriority",
-                                        "o_clerk",
-                                        "o_shippriority",
-                                        "o_comment"
+                                        "l_orderkey",
+                                        "l_partkey",
+                                        "l_suppkey",
+                                        "l_linenumber",
+                                        "l_quantity",
+                                        "l_extendedprice",
+                                        "l_discount",
+                                        "l_tax",
+                                        "l_returnflag",
+                                        "l_linestatus",
+                                        "l_shipdate",
+                                        "l_commitdate",
+                                        "l_receiptdate",
+                                        "l_shipinstruct",
+                                        "l_shipmode",
+                                        "l_comment"
                                       ],
                                       "struct": {
                                         "types": [
                                           {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "decimal": {
                                               "scale": 2,
                                               "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "date": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
                                           {
                                             "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           }
                                         ],
@@ -190,7 +393,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "orders"
+                                        "lineitem"
                                       ]
                                     }
                                   }
@@ -208,7 +411,9 @@
                                         "value": {
                                           "selection": {
                                             "directReference": {
-                                              "structField": {}
+                                              "structField": {
+                                                "field": 8
+                                              }
                                             },
                                             "rootReference": {}
                                           }
@@ -219,7 +424,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 9
+                                                "field": 17
                                               }
                                             },
                                             "rootReference": {}
@@ -232,168 +437,336 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "l_orderkey",
-                                    "l_partkey",
-                                    "l_suppkey",
-                                    "l_linenumber",
-                                    "l_quantity",
-                                    "l_extendedprice",
-                                    "l_discount",
-                                    "l_tax",
-                                    "l_returnflag",
-                                    "l_linestatus",
-                                    "l_shipdate",
-                                    "l_commitdate",
-                                    "l_receiptdate",
-                                    "l_shipinstruct",
-                                    "l_shipmode",
-                                    "l_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "lineitem"
-                                  ]
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
                                 }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 8
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 17
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
                                     }
-                                  }
-                                ]
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 25
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 26
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 27
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 28
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 29
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 30
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 31
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 32
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
                               }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
                         },
                         "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
@@ -86,246 +86,531 @@
             "input": {
               "filter": {
                 "input": {
-                  "join": {
-                    "left": {
-                      "read": {
-                        "common": {
-                          "direct": {}
-                        },
-                        "baseSchema": {
-                          "names": [
-                            "l_orderkey",
-                            "l_partkey",
-                            "l_suppkey",
-                            "l_linenumber",
-                            "l_quantity",
-                            "l_extendedprice",
-                            "l_discount",
-                            "l_tax",
-                            "l_returnflag",
-                            "l_linestatus",
-                            "l_shipdate",
-                            "l_commitdate",
-                            "l_receiptdate",
-                            "l_shipinstruct",
-                            "l_shipmode",
-                            "l_comment"
-                          ],
-                          "struct": {
-                            "types": [
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "date": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "date": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "date": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              }
-                            ],
-                            "nullability": "NULLABILITY_REQUIRED"
-                          }
-                        },
-                        "namedTable": {
-                          "names": [
-                            "lineitem"
-                          ]
-                        }
-                      }
-                    },
-                    "right": {
-                      "read": {
-                        "common": {
-                          "direct": {}
-                        },
-                        "baseSchema": {
-                          "names": [
-                            "p_partkey",
-                            "p_name",
-                            "p_mfgr",
-                            "p_brand",
-                            "p_type",
-                            "p_size",
-                            "p_container",
-                            "p_retailprice",
-                            "p_comment"
-                          ],
-                          "struct": {
-                            "types": [
-                              {
-                                "i32": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "i32": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              }
-                            ],
-                            "nullability": "NULLABILITY_REQUIRED"
-                          }
-                        },
-                        "namedTable": {
-                          "names": [
-                            "part"
-                          ]
-                        }
-                      }
-                    },
-                    "expression": {
-                      "scalarFunction": {
-                        "functionReference": 1,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "value": {
-                              "selection": {
-                                "directReference": {
-                                  "structField": {
-                                    "field": 16
-                                  }
-                                },
-                                "rootReference": {}
-                              }
-                            }
-                          },
-                          {
-                            "value": {
-                              "selection": {
-                                "directReference": {
-                                  "structField": {
-                                    "field": 1
-                                  }
-                                },
-                                "rootReference": {}
-                              }
-                            }
-                          }
+                  "project": {
+                    "common": {
+                      "emit": {
+                        "outputMapping": [
+                          25,
+                          26,
+                          27,
+                          28,
+                          29,
+                          30,
+                          31,
+                          32,
+                          33,
+                          34,
+                          35,
+                          36,
+                          37,
+                          38,
+                          39,
+                          40,
+                          41,
+                          42,
+                          43,
+                          44,
+                          45,
+                          46,
+                          47,
+                          48,
+                          49
                         ]
                       }
                     },
-                    "type": "JOIN_TYPE_INNER"
+                    "input": {
+                      "join": {
+                        "left": {
+                          "read": {
+                            "common": {
+                              "direct": {}
+                            },
+                            "baseSchema": {
+                              "names": [
+                                "l_orderkey",
+                                "l_partkey",
+                                "l_suppkey",
+                                "l_linenumber",
+                                "l_quantity",
+                                "l_extendedprice",
+                                "l_discount",
+                                "l_tax",
+                                "l_returnflag",
+                                "l_linestatus",
+                                "l_shipdate",
+                                "l_commitdate",
+                                "l_receiptdate",
+                                "l_shipinstruct",
+                                "l_shipmode",
+                                "l_comment"
+                              ],
+                              "struct": {
+                                "types": [
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "date": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "date": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "date": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  }
+                                ],
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "namedTable": {
+                              "names": [
+                                "lineitem"
+                              ]
+                            }
+                          }
+                        },
+                        "right": {
+                          "read": {
+                            "common": {
+                              "direct": {}
+                            },
+                            "baseSchema": {
+                              "names": [
+                                "p_partkey",
+                                "p_name",
+                                "p_mfgr",
+                                "p_brand",
+                                "p_type",
+                                "p_size",
+                                "p_container",
+                                "p_retailprice",
+                                "p_comment"
+                              ],
+                              "struct": {
+                                "types": [
+                                  {
+                                    "i32": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "i32": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  }
+                                ],
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "namedTable": {
+                              "names": [
+                                "part"
+                              ]
+                            }
+                          }
+                        },
+                        "expression": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 16
+                                      }
+                                    },
+                                    "rootReference": {}
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 1
+                                      }
+                                    },
+                                    "rootReference": {}
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "type": "JOIN_TYPE_INNER"
+                      }
+                    },
+                    "expressions": [
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {}
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 3
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 4
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 5
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 6
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 7
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 8
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 9
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 10
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 11
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 12
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 13
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 14
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 15
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 16
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 17
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 18
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 19
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 20
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 21
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 22
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 23
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 24
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      }
+                    ]
                   }
                 },
                 "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
@@ -93,154 +93,285 @@
                 "input": {
                   "filter": {
                     "input": {
-                      "join": {
-                        "left": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "s_suppkey",
-                                "s_name",
-                                "s_address",
-                                "s_nationkey",
-                                "s_phone",
-                                "s_acctbal",
-                                "s_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "supplier"
-                              ]
-                            }
-                          }
-                        },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "n_nationkey",
-                                "n_name",
-                                "n_regionkey",
-                                "n_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "nation"
-                              ]
-                            }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 3
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 7
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              }
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              11,
+                              12,
+                              13,
+                              14,
+                              15,
+                              16,
+                              17,
+                              18,
+                              19,
+                              20,
+                              21
                             ]
                           }
                         },
-                        "type": "JOIN_TYPE_INNER"
+                        "input": {
+                          "join": {
+                            "left": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "s_suppkey",
+                                    "s_name",
+                                    "s_address",
+                                    "s_nationkey",
+                                    "s_phone",
+                                    "s_acctbal",
+                                    "s_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "supplier"
+                                  ]
+                                }
+                              }
+                            },
+                            "right": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "n_nationkey",
+                                    "n_name",
+                                    "n_regionkey",
+                                    "n_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "nation"
+                                  ]
+                                }
+                              }
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 3
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 7
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "JOIN_TYPE_INNER"
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          }
+                        ]
                       }
                     },
                     "condition": {

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
@@ -69,74 +69,251 @@
                     "input": {
                       "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  36,
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
                                   "join": {
                                     "left": {
-                                      "read": {
-                                        "common": {
-                                          "direct": {}
-                                        },
-                                        "baseSchema": {
-                                          "names": [
-                                            "s_suppkey",
-                                            "s_name",
-                                            "s_address",
-                                            "s_nationkey",
-                                            "s_phone",
-                                            "s_acctbal",
-                                            "s_comment"
-                                          ],
-                                          "struct": {
-                                            "types": [
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
+                                      "join": {
+                                        "left": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "s_suppkey",
+                                                "s_name",
+                                                "s_address",
+                                                "s_nationkey",
+                                                "s_phone",
+                                                "s_acctbal",
+                                                "s_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
                                               }
-                                            ],
-                                            "nullability": "NULLABILITY_REQUIRED"
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "supplier"
+                                              ]
+                                            }
                                           }
                                         },
-                                        "namedTable": {
-                                          "names": [
-                                            "supplier"
-                                          ]
-                                        }
+                                        "right": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "l_orderkey",
+                                                "l_partkey",
+                                                "l_suppkey",
+                                                "l_linenumber",
+                                                "l_quantity",
+                                                "l_extendedprice",
+                                                "l_discount",
+                                                "l_tax",
+                                                "l_returnflag",
+                                                "l_linestatus",
+                                                "l_shipdate",
+                                                "l_commitdate",
+                                                "l_receiptdate",
+                                                "l_shipinstruct",
+                                                "l_shipmode",
+                                                "l_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                              }
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "lineitem"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "expression": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {}
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 9
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "JOIN_TYPE_INNER"
                                       }
                                     },
                                     "right": {
@@ -146,111 +323,63 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "l_orderkey",
-                                            "l_partkey",
-                                            "l_suppkey",
-                                            "l_linenumber",
-                                            "l_quantity",
-                                            "l_extendedprice",
-                                            "l_discount",
-                                            "l_tax",
-                                            "l_returnflag",
-                                            "l_linestatus",
-                                            "l_shipdate",
-                                            "l_commitdate",
-                                            "l_receiptdate",
-                                            "l_shipinstruct",
-                                            "l_shipmode",
-                                            "l_comment"
+                                            "o_orderkey",
+                                            "o_custkey",
+                                            "o_orderstatus",
+                                            "o_totalprice",
+                                            "o_orderdate",
+                                            "o_orderpriority",
+                                            "o_clerk",
+                                            "o_shippriority",
+                                            "o_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               }
                                             ],
@@ -259,7 +388,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "lineitem"
+                                            "orders"
                                           ]
                                         }
                                       }
@@ -277,7 +406,9 @@
                                             "value": {
                                               "selection": {
                                                 "directReference": {
-                                                  "structField": {}
+                                                  "structField": {
+                                                    "field": 23
+                                                  }
                                                 },
                                                 "rootReference": {}
                                               }
@@ -288,7 +419,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 9
+                                                    "field": 7
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -308,47 +439,15 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "o_orderkey",
-                                        "o_custkey",
-                                        "o_orderstatus",
-                                        "o_totalprice",
-                                        "o_orderdate",
-                                        "o_orderpriority",
-                                        "o_clerk",
-                                        "o_shippriority",
-                                        "o_comment"
+                                        "n_nationkey",
+                                        "n_name",
+                                        "n_regionkey",
+                                        "n_comment"
                                       ],
                                       "struct": {
                                         "types": [
                                           {
                                             "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
@@ -373,7 +472,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "orders"
+                                        "nation"
                                       ]
                                     }
                                   }
@@ -392,7 +491,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 23
+                                                "field": 3
                                               }
                                             },
                                             "rootReference": {}
@@ -404,7 +503,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 7
+                                                "field": 32
                                               }
                                             },
                                             "rootReference": {}
@@ -417,88 +516,78 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "n_nationkey",
-                                    "n_name",
-                                    "n_regionkey",
-                                    "n_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "nation"
-                                  ]
-                                }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 3
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 32
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 25
                                     }
-                                  }
-                                ]
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 33
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
                               }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
                         },
                         "condition": {

--- a/ibis_substrait/tests/compiler/test_parity.py
+++ b/ibis_substrait/tests/compiler/test_parity.py
@@ -125,6 +125,14 @@ def test_inner_join(consumer: str, request):
     run_parity_test(request.getfixturevalue(consumer), expr)
 
 
+@pytest.mark.parametrize("consumer", ["acero_consumer", "datafusion_consumer"])
+def test_inner_join_projection(consumer: str, request):
+    expr = orders.join(stores, orders["fk_store_id"] == stores["store_id"]).select(
+        "store_id"
+    )
+    run_parity_test(request.getfixturevalue(consumer), expr)
+
+
 @pytest.mark.parametrize(
     "consumer",
     [
@@ -197,13 +205,7 @@ def test_filter_groupby_count_distinct(consumer: str, request):
 
 @pytest.mark.parametrize(
     "consumer",
-    [
-        "acero_consumer",
-        pytest.param(
-            "datafusion_consumer",
-            marks=[pytest.mark.xfail(Exception, reason="")],
-        ),
-    ],
+    ["acero_consumer", "datafusion_consumer"],
 )
 def test_aggregate_having(consumer: str, request):
     expr = orders.aggregate(


### PR DESCRIPTION
Ibis IR has a bit of a quirky behavior around projections, namely one can define projections both in `ops.Project` object and also as part of `ops.JoinChain`, not sure why that's the case. Current compiler handles only projections defined in `ops.Project`, therefore any selects written after a join chain are ignored.

The PR fixes the issue by injecting a projection node after every join chain in the plan. Technically this is not always necessary, because if the values contained in the `ops.JoinChain` do only column renames and reorders (no new expressions) then substrait's Emit message inside JoinRel can be used as well, but that would require inspecting all values first to make sure that nothing other than field references are present in there. 