### PR TITLE
fix: workaround for aggregates in datafusion

### DIFF
--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
@@ -70,581 +70,701 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      10,
+                      11,
+                      12,
+                      13,
+                      14,
+                      15,
+                      16,
+                      17,
+                      18,
+                      19
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "read": {
-                        "common": {
-                          "direct": {}
-                        },
-                        "baseSchema": {
-                          "names": [
-                            "l_orderkey",
-                            "l_partkey",
-                            "l_suppkey",
-                            "l_linenumber",
-                            "l_quantity",
-                            "l_extendedprice",
-                            "l_discount",
-                            "l_tax",
-                            "l_returnflag",
-                            "l_linestatus",
-                            "l_shipdate",
-                            "l_commitdate",
-                            "l_receiptdate",
-                            "l_shipinstruct",
-                            "l_shipmode",
-                            "l_comment"
-                          ],
-                          "struct": {
-                            "types": [
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "i64": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "date": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "date": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "date": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
+                      "filter": {
+                        "input": {
+                          "read": {
+                            "common": {
+                              "direct": {}
+                            },
+                            "baseSchema": {
+                              "names": [
+                                "l_orderkey",
+                                "l_partkey",
+                                "l_suppkey",
+                                "l_linenumber",
+                                "l_quantity",
+                                "l_extendedprice",
+                                "l_discount",
+                                "l_tax",
+                                "l_returnflag",
+                                "l_linestatus",
+                                "l_shipdate",
+                                "l_commitdate",
+                                "l_receiptdate",
+                                "l_shipinstruct",
+                                "l_shipmode",
+                                "l_comment"
+                              ],
+                              "struct": {
+                                "types": [
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "date": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "date": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "date": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  }
+                                ],
+                                "nullability": "NULLABILITY_REQUIRED"
                               }
-                            ],
-                            "nullability": "NULLABILITY_REQUIRED"
+                            },
+                            "namedTable": {
+                              "names": [
+                                "lineitem"
+                              ]
+                            }
                           }
                         },
-                        "namedTable": {
-                          "names": [
-                            "lineitem"
-                          ]
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 10
+                                      }
+                                    },
+                                    "rootReference": {}
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "date": 10471
+                                  }
+                                }
+                              }
+                            ]
+                          }
                         }
                       }
                     },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 1,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
+                    "groupings": [
+                      {
+                        "groupingExpressions": [
                           {
-                            "value": {
-                              "selection": {
-                                "directReference": {
-                                  "structField": {
-                                    "field": 10
-                                  }
-                                },
-                                "rootReference": {}
-                              }
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
                             }
                           },
                           {
-                            "value": {
-                              "literal": {
-                                "date": 10471
-                              }
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
                             }
                           }
                         ]
                       }
-                    }
-                  }
-                },
-                "groupings": [
-                  {
-                    "groupingExpressions": [
+                    ],
+                    "measures": [
                       {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 8
+                        "measure": {
+                          "functionReference": 2,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
                             }
                           },
-                          "rootReference": {}
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
                         }
                       },
                       {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 9
+                        "measure": {
+                          "functionReference": 2,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
                             }
                           },
-                          "rootReference": {}
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 2,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "scalarFunction": {
+                                  "functionReference": 3,
+                                  "outputType": {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 5
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "value": {
+                                        "scalarFunction": {
+                                          "functionReference": 4,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "cast": {
+                                                  "type": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "input": {
+                                                    "literal": {
+                                                      "i8": 1
+                                                    }
+                                                  },
+                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 6
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 2,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "scalarFunction": {
+                                  "functionReference": 3,
+                                  "outputType": {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "value": {
+                                        "scalarFunction": {
+                                          "functionReference": 3,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 5
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "scalarFunction": {
+                                                  "functionReference": 4,
+                                                  "outputType": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "arguments": [
+                                                    {
+                                                      "value": {
+                                                        "cast": {
+                                                          "type": {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "input": {
+                                                            "literal": {
+                                                              "i8": 1
+                                                            }
+                                                          },
+                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "value": {
+                                                        "selection": {
+                                                          "directReference": {
+                                                            "structField": {
+                                                              "field": 6
+                                                            }
+                                                          },
+                                                          "rootReference": {}
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "value": {
+                                        "scalarFunction": {
+                                          "functionReference": 5,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 7
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "cast": {
+                                                  "type": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "input": {
+                                                    "literal": {
+                                                      "i8": 1
+                                                    }
+                                                  },
+                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 6,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 15,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 6,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 15,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 6,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 15,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 7,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
                         }
                       }
                     ]
                   }
-                ],
-                "measures": [
+                },
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 2,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 2,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 2,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 2
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "scalarFunction": {
-                              "functionReference": 3,
-                              "outputType": {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "value": {
-                                    "selection": {
-                                      "directReference": {
-                                        "structField": {
-                                          "field": 5
-                                        }
-                                      },
-                                      "rootReference": {}
-                                    }
-                                  }
-                                },
-                                {
-                                  "value": {
-                                    "scalarFunction": {
-                                      "functionReference": 4,
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "cast": {
-                                              "type": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "i8": 1
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 6
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 2,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 3
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "scalarFunction": {
-                              "functionReference": 3,
-                              "outputType": {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "value": {
-                                    "scalarFunction": {
-                                      "functionReference": 3,
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 5
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "scalarFunction": {
-                                              "functionReference": 4,
-                                              "outputType": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "arguments": [
-                                                {
-                                                  "value": {
-                                                    "cast": {
-                                                      "type": {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "input": {
-                                                        "literal": {
-                                                          "i8": 1
-                                                        }
-                                                      },
-                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                    }
-                                                  }
-                                                },
-                                                {
-                                                  "value": {
-                                                    "selection": {
-                                                      "directReference": {
-                                                        "structField": {
-                                                          "field": 6
-                                                        }
-                                                      },
-                                                      "rootReference": {}
-                                                    }
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "value": {
-                                    "scalarFunction": {
-                                      "functionReference": 5,
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 7
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "cast": {
-                                              "type": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "i8": 1
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 6,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 15,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 4
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 6,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 15,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 5
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 6,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 15,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 6
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 6
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 7,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 7
                         }
-                      }
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 8
+                        }
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 9
+                        }
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h02/tpc_h02.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h02/tpc_h02.json
@@ -994,93 +994,206 @@
                                           "subquery": {
                                             "scalar": {
                                               "input": {
-                                                "aggregate": {
+                                                "project": {
+                                                  "common": {
+                                                    "emit": {
+                                                      "outputMapping": [
+                                                        1
+                                                      ]
+                                                    }
+                                                  },
                                                   "input": {
-                                                    "filter": {
+                                                    "aggregate": {
                                                       "input": {
-                                                        "project": {
-                                                          "common": {
-                                                            "emit": {
-                                                              "outputMapping": [
-                                                                19,
-                                                                20,
-                                                                21,
-                                                                22,
-                                                                23,
-                                                                24,
-                                                                25,
-                                                                26,
-                                                                27,
-                                                                28,
-                                                                29,
-                                                                30,
-                                                                31,
-                                                                32,
-                                                                33,
-                                                                34,
-                                                                35,
-                                                                36,
-                                                                37
-                                                              ]
-                                                            }
-                                                          },
+                                                        "filter": {
                                                           "input": {
-                                                            "join": {
-                                                              "left": {
+                                                            "project": {
+                                                              "common": {
+                                                                "emit": {
+                                                                  "outputMapping": [
+                                                                    19,
+                                                                    20,
+                                                                    21,
+                                                                    22,
+                                                                    23,
+                                                                    24,
+                                                                    25,
+                                                                    26,
+                                                                    27,
+                                                                    28,
+                                                                    29,
+                                                                    30,
+                                                                    31,
+                                                                    32,
+                                                                    33,
+                                                                    34,
+                                                                    35,
+                                                                    36,
+                                                                    37
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "input": {
                                                                 "join": {
                                                                   "left": {
                                                                     "join": {
                                                                       "left": {
-                                                                        "read": {
-                                                                          "common": {
-                                                                            "direct": {}
-                                                                          },
-                                                                          "baseSchema": {
-                                                                            "names": [
-                                                                              "ps_partkey",
-                                                                              "ps_suppkey",
-                                                                              "ps_availqty",
-                                                                              "ps_supplycost",
-                                                                              "ps_comment"
-                                                                            ],
-                                                                            "struct": {
-                                                                              "types": [
-                                                                                {
-                                                                                  "i32": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                },
-                                                                                {
-                                                                                  "i32": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                },
-                                                                                {
-                                                                                  "i32": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                },
-                                                                                {
-                                                                                  "decimal": {
-                                                                                    "scale": 2,
-                                                                                    "precision": 15,
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                },
-                                                                                {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
+                                                                        "join": {
+                                                                          "left": {
+                                                                            "read": {
+                                                                              "common": {
+                                                                                "direct": {}
+                                                                              },
+                                                                              "baseSchema": {
+                                                                                "names": [
+                                                                                  "ps_partkey",
+                                                                                  "ps_suppkey",
+                                                                                  "ps_availqty",
+                                                                                  "ps_supplycost",
+                                                                                  "ps_comment"
+                                                                                ],
+                                                                                "struct": {
+                                                                                  "types": [
+                                                                                    {
+                                                                                      "i32": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "i32": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "i32": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "decimal": {
+                                                                                        "scale": 2,
+                                                                                        "precision": 15,
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }
+                                                                                  ],
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
                                                                                 }
-                                                                              ],
-                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                              },
+                                                                              "namedTable": {
+                                                                                "names": [
+                                                                                  "partsupp"
+                                                                                ]
+                                                                              }
                                                                             }
                                                                           },
-                                                                          "namedTable": {
-                                                                            "names": [
-                                                                              "partsupp"
-                                                                            ]
-                                                                          }
+                                                                          "right": {
+                                                                            "read": {
+                                                                              "common": {
+                                                                                "direct": {}
+                                                                              },
+                                                                              "baseSchema": {
+                                                                                "names": [
+                                                                                  "s_suppkey",
+                                                                                  "s_name",
+                                                                                  "s_address",
+                                                                                  "s_nationkey",
+                                                                                  "s_phone",
+                                                                                  "s_acctbal",
+                                                                                  "s_comment"
+                                                                                ],
+                                                                                "struct": {
+                                                                                  "types": [
+                                                                                    {
+                                                                                      "i32": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "i32": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "decimal": {
+                                                                                        "scale": 2,
+                                                                                        "precision": 15,
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "string": {
+                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                      }
+                                                                                    }
+                                                                                  ],
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              "namedTable": {
+                                                                                "names": [
+                                                                                  "supplier"
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "expression": {
+                                                                            "scalarFunction": {
+                                                                              "functionReference": 1,
+                                                                              "outputType": {
+                                                                                "bool": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              "arguments": [
+                                                                                {
+                                                                                  "value": {
+                                                                                    "selection": {
+                                                                                      "directReference": {
+                                                                                        "structField": {
+                                                                                          "field": 5
+                                                                                        }
+                                                                                      },
+                                                                                      "rootReference": {}
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "value": {
+                                                                                    "selection": {
+                                                                                      "directReference": {
+                                                                                        "structField": {
+                                                                                          "field": 1
+                                                                                        }
+                                                                                      },
+                                                                                      "rootReference": {}
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "JOIN_TYPE_INNER"
                                                                         }
                                                                       },
                                                                       "right": {
@@ -1090,13 +1203,10 @@
                                                                           },
                                                                           "baseSchema": {
                                                                             "names": [
-                                                                              "s_suppkey",
-                                                                              "s_name",
-                                                                              "s_address",
-                                                                              "s_nationkey",
-                                                                              "s_phone",
-                                                                              "s_acctbal",
-                                                                              "s_comment"
+                                                                              "n_nationkey",
+                                                                              "n_name",
+                                                                              "n_regionkey",
+                                                                              "n_comment"
                                                                             ],
                                                                             "struct": {
                                                                               "types": [
@@ -1111,24 +1221,7 @@
                                                                                   }
                                                                                 },
                                                                                 {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                },
-                                                                                {
                                                                                   "i32": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                },
-                                                                                {
-                                                                                  "string": {
-                                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                                  }
-                                                                                },
-                                                                                {
-                                                                                  "decimal": {
-                                                                                    "scale": 2,
-                                                                                    "precision": 15,
                                                                                     "nullability": "NULLABILITY_REQUIRED"
                                                                                   }
                                                                                 },
@@ -1143,7 +1236,7 @@
                                                                           },
                                                                           "namedTable": {
                                                                             "names": [
-                                                                              "supplier"
+                                                                              "nation"
                                                                             ]
                                                                           }
                                                                         }
@@ -1162,7 +1255,7 @@
                                                                                 "selection": {
                                                                                   "directReference": {
                                                                                     "structField": {
-                                                                                      "field": 5
+                                                                                      "field": 8
                                                                                     }
                                                                                   },
                                                                                   "rootReference": {}
@@ -1174,7 +1267,7 @@
                                                                                 "selection": {
                                                                                   "directReference": {
                                                                                     "structField": {
-                                                                                      "field": 1
+                                                                                      "field": 12
                                                                                     }
                                                                                   },
                                                                                   "rootReference": {}
@@ -1194,10 +1287,9 @@
                                                                       },
                                                                       "baseSchema": {
                                                                         "names": [
-                                                                          "n_nationkey",
-                                                                          "n_name",
-                                                                          "n_regionkey",
-                                                                          "n_comment"
+                                                                          "r_regionkey",
+                                                                          "r_name",
+                                                                          "r_comment"
                                                                         ],
                                                                         "struct": {
                                                                           "types": [
@@ -1212,11 +1304,6 @@
                                                                               }
                                                                             },
                                                                             {
-                                                                              "i32": {
-                                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                                              }
-                                                                            },
-                                                                            {
                                                                               "string": {
                                                                                 "nullability": "NULLABILITY_REQUIRED"
                                                                               }
@@ -1227,7 +1314,7 @@
                                                                       },
                                                                       "namedTable": {
                                                                         "names": [
-                                                                          "nation"
+                                                                          "region"
                                                                         ]
                                                                       }
                                                                     }
@@ -1246,7 +1333,7 @@
                                                                             "selection": {
                                                                               "directReference": {
                                                                                 "structField": {
-                                                                                  "field": 8
+                                                                                  "field": 14
                                                                                 }
                                                                               },
                                                                               "rootReference": {}
@@ -1258,7 +1345,7 @@
                                                                             "selection": {
                                                                               "directReference": {
                                                                                 "structField": {
-                                                                                  "field": 12
+                                                                                  "field": 16
                                                                                 }
                                                                               },
                                                                               "rootReference": {}
@@ -1271,386 +1358,320 @@
                                                                   "type": "JOIN_TYPE_INNER"
                                                                 }
                                                               },
-                                                              "right": {
-                                                                "read": {
-                                                                  "common": {
-                                                                    "direct": {}
-                                                                  },
-                                                                  "baseSchema": {
-                                                                    "names": [
-                                                                      "r_regionkey",
-                                                                      "r_name",
-                                                                      "r_comment"
-                                                                    ],
-                                                                    "struct": {
-                                                                      "types": [
-                                                                        {
-                                                                          "i32": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "string": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "string": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        }
-                                                                      ],
-                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                    }
-                                                                  },
-                                                                  "namedTable": {
-                                                                    "names": [
-                                                                      "region"
-                                                                    ]
+                                                              "expressions": [
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {}
+                                                                    },
+                                                                    "rootReference": {}
                                                                   }
-                                                                }
-                                                              },
-                                                              "expression": {
-                                                                "scalarFunction": {
-                                                                  "functionReference": 1,
-                                                                  "outputType": {
-                                                                    "bool": {
-                                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                                    }
-                                                                  },
-                                                                  "arguments": [
-                                                                    {
-                                                                      "value": {
-                                                                        "selection": {
-                                                                          "directReference": {
-                                                                            "structField": {
-                                                                              "field": 14
-                                                                            }
-                                                                          },
-                                                                          "rootReference": {}
-                                                                        }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 1
                                                                       }
                                                                     },
-                                                                    {
-                                                                      "value": {
-                                                                        "selection": {
-                                                                          "directReference": {
-                                                                            "structField": {
-                                                                              "field": 16
-                                                                            }
-                                                                          },
-                                                                          "rootReference": {}
-                                                                        }
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 2
                                                                       }
-                                                                    }
-                                                                  ]
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 3
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 4
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 5
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 6
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 7
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 8
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 9
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 10
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 11
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 12
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 13
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 14
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 15
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 16
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 17
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 18
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
                                                                 }
-                                                              },
-                                                              "type": "JOIN_TYPE_INNER"
+                                                              ]
                                                             }
                                                           },
-                                                          "expressions": [
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {}
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 1
+                                                          "condition": {
+                                                            "scalarFunction": {
+                                                              "functionReference": 2,
+                                                              "outputType": {
+                                                                "bool": {
+                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                              },
+                                                              "arguments": [
+                                                                {
+                                                                  "value": {
+                                                                    "scalarFunction": {
+                                                                      "functionReference": 1,
+                                                                      "outputType": {
+                                                                        "bool": {
+                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                        }
+                                                                      },
+                                                                      "arguments": [
+                                                                        {
+                                                                          "value": {
+                                                                            "selection": {
+                                                                              "directReference": {
+                                                                                "structField": {
+                                                                                  "field": 17
+                                                                                }
+                                                                              },
+                                                                              "rootReference": {}
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "value": {
+                                                                            "literal": {
+                                                                              "string": "EUROPE"
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      ]
+                                                                    }
                                                                   }
                                                                 },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 2
+                                                                {
+                                                                  "value": {
+                                                                    "scalarFunction": {
+                                                                      "functionReference": 1,
+                                                                      "outputType": {
+                                                                        "bool": {
+                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                        }
+                                                                      },
+                                                                      "arguments": [
+                                                                        {
+                                                                          "value": {
+                                                                            "selection": {
+                                                                              "directReference": {
+                                                                                "structField": {}
+                                                                              },
+                                                                              "rootReference": {}
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "value": {
+                                                                            "selection": {
+                                                                              "directReference": {
+                                                                                "structField": {}
+                                                                              },
+                                                                              "rootReference": {}
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      ]
+                                                                    }
                                                                   }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 3
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 4
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 5
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 6
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 7
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 8
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 9
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 10
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 11
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 12
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 13
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 14
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 15
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 16
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 17
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            },
-                                                            {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 18
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
+                                                                }
+                                                              ]
                                                             }
-                                                          ]
+                                                          }
                                                         }
                                                       },
-                                                      "condition": {
-                                                        "scalarFunction": {
-                                                          "functionReference": 2,
-                                                          "outputType": {
-                                                            "bool": {
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "arguments": [
-                                                            {
-                                                              "value": {
-                                                                "scalarFunction": {
-                                                                  "functionReference": 1,
-                                                                  "outputType": {
-                                                                    "bool": {
-                                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                                    }
-                                                                  },
-                                                                  "arguments": [
-                                                                    {
-                                                                      "value": {
-                                                                        "selection": {
-                                                                          "directReference": {
-                                                                            "structField": {
-                                                                              "field": 17
-                                                                            }
-                                                                          },
-                                                                          "rootReference": {}
-                                                                        }
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "value": {
-                                                                        "literal": {
-                                                                          "string": "EUROPE"
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  ]
-                                                                }
+                                                      "groupings": [
+                                                        {}
+                                                      ],
+                                                      "measures": [
+                                                        {
+                                                          "measure": {
+                                                            "functionReference": 4,
+                                                            "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                            "outputType": {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
                                                               }
                                                             },
-                                                            {
-                                                              "value": {
-                                                                "scalarFunction": {
-                                                                  "functionReference": 1,
-                                                                  "outputType": {
-                                                                    "bool": {
-                                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                                    }
-                                                                  },
-                                                                  "arguments": [
-                                                                    {
-                                                                      "value": {
-                                                                        "selection": {
-                                                                          "directReference": {
-                                                                            "structField": {}
-                                                                          },
-                                                                          "rootReference": {}
-                                                                        }
+                                                            "arguments": [
+                                                              {
+                                                                "value": {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 3
                                                                       }
                                                                     },
-                                                                    {
-                                                                      "value": {
-                                                                        "selection": {
-                                                                          "directReference": {
-                                                                            "structField": {}
-                                                                          },
-                                                                          "rootReference": {}
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  ]
+                                                                    "rootReference": {}
+                                                                  }
                                                                 }
                                                               }
-                                                            }
-                                                          ]
+                                                            ]
+                                                          }
                                                         }
-                                                      }
+                                                      ]
                                                     }
                                                   },
-                                                  "groupings": [
-                                                    {}
-                                                  ],
-                                                  "measures": [
+                                                  "expressions": [
                                                     {
-                                                      "measure": {
-                                                        "functionReference": 4,
-                                                        "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                        "outputType": {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
                                                         },
-                                                        "arguments": [
-                                                          {
-                                                            "value": {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 3
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            }
-                                                          }
-                                                        ]
+                                                        "rootReference": {}
                                                       }
                                                     }
                                                   ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
@@ -72,123 +72,249 @@
             "input": {
               "sort": {
                 "input": {
-                  "aggregate": {
+                  "project": {
+                    "common": {
+                      "emit": {
+                        "outputMapping": [
+                          4,
+                          5,
+                          6,
+                          7
+                        ]
+                      }
+                    },
                     "input": {
-                      "filter": {
+                      "aggregate": {
                         "input": {
-                          "project": {
-                            "common": {
-                              "emit": {
-                                "outputMapping": [
-                                  33,
-                                  34,
-                                  35,
-                                  36,
-                                  37,
-                                  38,
-                                  39,
-                                  40,
-                                  41,
-                                  42,
-                                  43,
-                                  44,
-                                  45,
-                                  46,
-                                  47,
-                                  48,
-                                  49,
-                                  50,
-                                  51,
-                                  52,
-                                  53,
-                                  54,
-                                  55,
-                                  56,
-                                  57,
-                                  58,
-                                  59,
-                                  60,
-                                  61,
-                                  62,
-                                  63,
-                                  64,
-                                  65
-                                ]
-                              }
-                            },
+                          "filter": {
                             "input": {
-                              "join": {
-                                "left": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      33,
+                                      34,
+                                      35,
+                                      36,
+                                      37,
+                                      38,
+                                      39,
+                                      40,
+                                      41,
+                                      42,
+                                      43,
+                                      44,
+                                      45,
+                                      46,
+                                      47,
+                                      48,
+                                      49,
+                                      50,
+                                      51,
+                                      52,
+                                      53,
+                                      54,
+                                      55,
+                                      56,
+                                      57,
+                                      58,
+                                      59,
+                                      60,
+                                      61,
+                                      62,
+                                      63,
+                                      64,
+                                      65
+                                    ]
+                                  }
+                                },
+                                "input": {
                                   "join": {
                                     "left": {
-                                      "read": {
-                                        "common": {
-                                          "direct": {}
-                                        },
-                                        "baseSchema": {
-                                          "names": [
-                                            "c_custkey",
-                                            "c_name",
-                                            "c_address",
-                                            "c_nationkey",
-                                            "c_phone",
-                                            "c_acctbal",
-                                            "c_mktsegment",
-                                            "c_comment"
-                                          ],
-                                          "struct": {
-                                            "types": [
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
+                                      "join": {
+                                        "left": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "c_custkey",
+                                                "c_name",
+                                                "c_address",
+                                                "c_nationkey",
+                                                "c_phone",
+                                                "c_acctbal",
+                                                "c_mktsegment",
+                                                "c_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
                                               }
-                                            ],
-                                            "nullability": "NULLABILITY_REQUIRED"
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "customer"
+                                              ]
+                                            }
                                           }
                                         },
-                                        "namedTable": {
-                                          "names": [
-                                            "customer"
-                                          ]
-                                        }
+                                        "right": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "o_orderkey",
+                                                "o_custkey",
+                                                "o_orderstatus",
+                                                "o_totalprice",
+                                                "o_orderdate",
+                                                "o_orderpriority",
+                                                "o_clerk",
+                                                "o_shippriority",
+                                                "o_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                              }
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "orders"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "expression": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {}
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 9
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "JOIN_TYPE_INNER"
                                       }
                                     },
                                     "right": {
@@ -198,63 +324,111 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "o_orderkey",
-                                            "o_custkey",
-                                            "o_orderstatus",
-                                            "o_totalprice",
-                                            "o_orderdate",
-                                            "o_orderpriority",
-                                            "o_clerk",
-                                            "o_shippriority",
-                                            "o_comment"
+                                            "l_orderkey",
+                                            "l_partkey",
+                                            "l_suppkey",
+                                            "l_linenumber",
+                                            "l_quantity",
+                                            "l_extendedprice",
+                                            "l_discount",
+                                            "l_tax",
+                                            "l_returnflag",
+                                            "l_linestatus",
+                                            "l_shipdate",
+                                            "l_commitdate",
+                                            "l_receiptdate",
+                                            "l_shipinstruct",
+                                            "l_shipmode",
+                                            "l_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "decimal": {
                                                   "scale": 2,
                                                   "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "date": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               }
                                             ],
@@ -263,7 +437,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "orders"
+                                            "lineitem"
                                           ]
                                         }
                                       }
@@ -281,7 +455,9 @@
                                             "value": {
                                               "selection": {
                                                 "directReference": {
-                                                  "structField": {}
+                                                  "structField": {
+                                                    "field": 17
+                                                  }
                                                 },
                                                 "rootReference": {}
                                               }
@@ -292,7 +468,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 9
+                                                    "field": 8
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -305,284 +481,473 @@
                                     "type": "JOIN_TYPE_INNER"
                                   }
                                 },
-                                "right": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "l_orderkey",
-                                        "l_partkey",
-                                        "l_suppkey",
-                                        "l_linenumber",
-                                        "l_quantity",
-                                        "l_extendedprice",
-                                        "l_discount",
-                                        "l_tax",
-                                        "l_returnflag",
-                                        "l_linestatus",
-                                        "l_shipdate",
-                                        "l_commitdate",
-                                        "l_receiptdate",
-                                        "l_shipinstruct",
-                                        "l_shipmode",
-                                        "l_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "lineitem"
-                                      ]
+                                "expressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
                                     }
-                                  }
-                                },
-                                "expression": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 17
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
                                         }
                                       },
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 8
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 2
                                         }
-                                      }
-                                    ]
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 3
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 7
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 8
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 9
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 10
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 11
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 12
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 13
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 14
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 15
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 16
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 17
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 18
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 19
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 20
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 21
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 22
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 23
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 24
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 25
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 26
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 27
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 28
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 29
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 30
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 31
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 32
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
                                   }
-                                },
-                                "type": "JOIN_TYPE_INNER"
+                                ]
                               }
                             },
-                            "expressions": [
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {}
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 1
+                            "condition": {
+                              "scalarFunction": {
+                                "functionReference": 2,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 2,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 6
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "BUILDING"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 12
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "1995-03-15"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
                                     }
                                   },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 2
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 4,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 27
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "literal": {
+                                                "string": "1995-03-15"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
                                     }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "groupings": [
+                          {
+                            "groupingExpressions": [
                               {
                                 "selection": {
                                   "directReference": {
                                     "structField": {
-                                      "field": 3
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 4
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 5
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 6
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 7
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 8
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 9
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 10
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 11
+                                      "field": 17
                                     }
                                   },
                                   "rootReference": {}
@@ -602,457 +967,146 @@
                                 "selection": {
                                   "directReference": {
                                     "structField": {
-                                      "field": 13
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 14
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
                                       "field": 15
                                     }
                                   },
                                   "rootReference": {}
                                 }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 16
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 17
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 18
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 19
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 20
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 21
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 22
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 23
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 24
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 25
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 26
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 27
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 28
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 29
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 30
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 31
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 32
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
                               }
                             ]
                           }
-                        },
-                        "condition": {
-                          "scalarFunction": {
-                            "functionReference": 2,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 2,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 1,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 6
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "BUILDING"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
+                        ],
+                        "measures": [
+                          {
+                            "measure": {
+                              "functionReference": 5,
+                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 38,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 6,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
                                         }
                                       },
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 12
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 22
                                                 }
                                               },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "1995-03-15"
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "scalarFunction": {
+                                              "functionReference": 7,
+                                              "outputType": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "cast": {
+                                                      "type": {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "input": {
+                                                        "literal": {
+                                                          "i8": 1
+                                                        }
+                                                      },
+                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 23
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
                                                   }
                                                 }
-                                              }
-                                            ]
+                                              ]
+                                            }
                                           }
                                         }
-                                      }
-                                    ]
+                                      ]
+                                    }
                                   }
                                 }
-                              },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 4,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 27
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "literal": {
-                                            "string": "1995-03-15"
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    },
-                    "groupings": [
-                      {
-                        "groupingExpressions": [
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 17
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 15
-                                }
-                              },
-                              "rootReference": {}
+                              ]
                             }
                           }
                         ]
                       }
-                    ],
-                    "measures": [
+                    },
+                    "expressions": [
                       {
-                        "measure": {
-                          "functionReference": 5,
-                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 38,
-                              "nullability": "NULLABILITY_NULLABLE"
+                        "selection": {
+                          "directReference": {
+                            "structField": {}
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
                             }
                           },
-                          "arguments": [
-                            {
-                              "value": {
-                                "scalarFunction": {
-                                  "functionReference": 6,
-                                  "outputType": {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "value": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 22
-                                            }
-                                          },
-                                          "rootReference": {}
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "value": {
-                                        "scalarFunction": {
-                                          "functionReference": 7,
-                                          "outputType": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "cast": {
-                                                  "type": {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  "input": {
-                                                    "literal": {
-                                                      "i8": 1
-                                                    }
-                                                  },
-                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 23
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
                             }
-                          ]
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 3
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
@@ -56,428 +56,460 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      2,
+                      3
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "read": {
-                        "common": {
-                          "direct": {}
-                        },
-                        "baseSchema": {
-                          "names": [
-                            "o_orderkey",
-                            "o_custkey",
-                            "o_orderstatus",
-                            "o_totalprice",
-                            "o_orderdate",
-                            "o_orderpriority",
-                            "o_clerk",
-                            "o_shippriority",
-                            "o_comment"
-                          ],
-                          "struct": {
-                            "types": [
-                              {
-                                "i32": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "i32": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "date": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "i32": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              },
-                              {
-                                "string": {
-                                  "nullability": "NULLABILITY_REQUIRED"
-                                }
-                              }
-                            ],
-                            "nullability": "NULLABILITY_REQUIRED"
-                          }
-                        },
-                        "namedTable": {
-                          "names": [
-                            "orders"
-                          ]
-                        }
-                      }
-                    },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 1,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
+                      "filter": {
+                        "input": {
+                          "read": {
+                            "common": {
+                              "direct": {}
+                            },
+                            "baseSchema": {
+                              "names": [
+                                "o_orderkey",
+                                "o_custkey",
+                                "o_orderstatus",
+                                "o_totalprice",
+                                "o_orderdate",
+                                "o_orderpriority",
+                                "o_clerk",
+                                "o_shippriority",
+                                "o_comment"
+                              ],
+                              "struct": {
+                                "types": [
                                   {
-                                    "value": {
-                                      "subquery": {
-                                        "setPredicate": {
-                                          "predicateOp": "PREDICATE_OP_EXISTS",
-                                          "tuples": {
-                                            "filter": {
-                                              "input": {
-                                                "read": {
-                                                  "common": {
-                                                    "direct": {}
-                                                  },
-                                                  "baseSchema": {
-                                                    "names": [
-                                                      "l_orderkey",
-                                                      "l_partkey",
-                                                      "l_suppkey",
-                                                      "l_linenumber",
-                                                      "l_quantity",
-                                                      "l_extendedprice",
-                                                      "l_discount",
-                                                      "l_tax",
-                                                      "l_returnflag",
-                                                      "l_linestatus",
-                                                      "l_shipdate",
-                                                      "l_commitdate",
-                                                      "l_receiptdate",
-                                                      "l_shipinstruct",
-                                                      "l_shipmode",
-                                                      "l_comment"
-                                                    ],
-                                                    "struct": {
-                                                      "types": [
-                                                        {
-                                                          "i64": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "i64": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "i64": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "i64": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "date": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "date": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "date": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
+                                    "i32": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "i32": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "date": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "i32": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  },
+                                  {
+                                    "string": {
+                                      "nullability": "NULLABILITY_REQUIRED"
+                                    }
+                                  }
+                                ],
+                                "nullability": "NULLABILITY_REQUIRED"
+                              }
+                            },
+                            "namedTable": {
+                              "names": [
+                                "orders"
+                              ]
+                            }
+                          }
+                        },
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 1,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 1,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "subquery": {
+                                            "setPredicate": {
+                                              "predicateOp": "PREDICATE_OP_EXISTS",
+                                              "tuples": {
+                                                "filter": {
+                                                  "input": {
+                                                    "read": {
+                                                      "common": {
+                                                        "direct": {}
+                                                      },
+                                                      "baseSchema": {
+                                                        "names": [
+                                                          "l_orderkey",
+                                                          "l_partkey",
+                                                          "l_suppkey",
+                                                          "l_linenumber",
+                                                          "l_quantity",
+                                                          "l_extendedprice",
+                                                          "l_discount",
+                                                          "l_tax",
+                                                          "l_returnflag",
+                                                          "l_linestatus",
+                                                          "l_shipdate",
+                                                          "l_commitdate",
+                                                          "l_receiptdate",
+                                                          "l_shipinstruct",
+                                                          "l_shipmode",
+                                                          "l_comment"
+                                                        ],
+                                                        "struct": {
+                                                          "types": [
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "date": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "date": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "date": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
-                                                      ],
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      },
+                                                      "namedTable": {
+                                                        "names": [
+                                                          "lineitem"
+                                                        ]
+                                                      }
                                                     }
                                                   },
-                                                  "namedTable": {
-                                                    "names": [
-                                                      "lineitem"
-                                                    ]
+                                                  "condition": {
+                                                    "scalarFunction": {
+                                                      "functionReference": 1,
+                                                      "outputType": {
+                                                        "bool": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "arguments": [
+                                                        {
+                                                          "value": {
+                                                            "scalarFunction": {
+                                                              "functionReference": 2,
+                                                              "outputType": {
+                                                                "bool": {
+                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                              },
+                                                              "arguments": [
+                                                                {
+                                                                  "value": {
+                                                                    "selection": {
+                                                                      "directReference": {
+                                                                        "structField": {}
+                                                                      },
+                                                                      "rootReference": {}
+                                                                    }
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "value": {
+                                                                    "selection": {
+                                                                      "directReference": {
+                                                                        "structField": {}
+                                                                      },
+                                                                      "rootReference": {}
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "value": {
+                                                            "scalarFunction": {
+                                                              "functionReference": 3,
+                                                              "outputType": {
+                                                                "bool": {
+                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                              },
+                                                              "arguments": [
+                                                                {
+                                                                  "value": {
+                                                                    "selection": {
+                                                                      "directReference": {
+                                                                        "structField": {
+                                                                          "field": 11
+                                                                        }
+                                                                      },
+                                                                      "rootReference": {}
+                                                                    }
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "value": {
+                                                                    "selection": {
+                                                                      "directReference": {
+                                                                        "structField": {
+                                                                          "field": 12
+                                                                        }
+                                                                      },
+                                                                      "rootReference": {}
+                                                                    }
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
                                                   }
-                                                }
-                                              },
-                                              "condition": {
-                                                "scalarFunction": {
-                                                  "functionReference": 1,
-                                                  "outputType": {
-                                                    "bool": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  "arguments": [
-                                                    {
-                                                      "value": {
-                                                        "scalarFunction": {
-                                                          "functionReference": 2,
-                                                          "outputType": {
-                                                            "bool": {
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "arguments": [
-                                                            {
-                                                              "value": {
-                                                                "selection": {
-                                                                  "directReference": {
-                                                                    "structField": {}
-                                                                  },
-                                                                  "rootReference": {}
-                                                                }
-                                                              }
-                                                            },
-                                                            {
-                                                              "value": {
-                                                                "selection": {
-                                                                  "directReference": {
-                                                                    "structField": {}
-                                                                  },
-                                                                  "rootReference": {}
-                                                                }
-                                                              }
-                                                            }
-                                                          ]
-                                                        }
-                                                      }
-                                                    },
-                                                    {
-                                                      "value": {
-                                                        "scalarFunction": {
-                                                          "functionReference": 3,
-                                                          "outputType": {
-                                                            "bool": {
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "arguments": [
-                                                            {
-                                                              "value": {
-                                                                "selection": {
-                                                                  "directReference": {
-                                                                    "structField": {
-                                                                      "field": 11
-                                                                    }
-                                                                  },
-                                                                  "rootReference": {}
-                                                                }
-                                                              }
-                                                            },
-                                                            {
-                                                              "value": {
-                                                                "selection": {
-                                                                  "directReference": {
-                                                                    "structField": {
-                                                                      "field": 12
-                                                                    }
-                                                                  },
-                                                                  "rootReference": {}
-                                                                }
-                                                              }
-                                                            }
-                                                          ]
-                                                        }
-                                                      }
-                                                    }
-                                                  ]
                                                 }
                                               }
                                             }
                                           }
                                         }
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 4,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 4
+                                      },
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 4,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 4
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
-                                                },
-                                                "rootReference": {}
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "literal": {
+                                                    "string": "1993-07-01"
+                                                  }
+                                                }
                                               }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "literal": {
-                                                "string": "1993-07-01"
-                                              }
-                                            }
+                                            ]
                                           }
-                                        ]
+                                        }
                                       }
-                                    }
+                                    ]
                                   }
-                                ]
+                                }
+                              },
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 3,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 4
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "string": "1993-10-01"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
                               }
-                            }
-                          },
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "groupings": [
+                      {
+                        "groupingExpressions": [
                           {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 3,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 4
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "literal": {
-                                        "string": "1993-10-01"
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
                             }
                           }
                         ]
                       }
-                    }
-                  }
-                },
-                "groupings": [
-                  {
-                    "groupingExpressions": [
+                    ],
+                    "measures": [
                       {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 5
+                        "measure": {
+                          "functionReference": 5,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
                             }
-                          },
-                          "rootReference": {}
+                          }
                         }
                       }
                     ]
                   }
-                ],
-                "measures": [
+                },
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 5,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
-                      }
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
@@ -70,67 +70,75 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      2,
+                      3
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "project": {
-                        "common": {
-                          "emit": {
-                            "outputMapping": [
-                              47,
-                              48,
-                              49,
-                              50,
-                              51,
-                              52,
-                              53,
-                              54,
-                              55,
-                              56,
-                              57,
-                              58,
-                              59,
-                              60,
-                              61,
-                              62,
-                              63,
-                              64,
-                              65,
-                              66,
-                              67,
-                              68,
-                              69,
-                              70,
-                              71,
-                              72,
-                              73,
-                              74,
-                              75,
-                              76,
-                              77,
-                              78,
-                              79,
-                              80,
-                              81,
-                              82,
-                              83,
-                              84,
-                              85,
-                              86,
-                              87,
-                              88,
-                              89,
-                              90,
-                              91,
-                              92,
-                              93
-                            ]
-                          }
-                        },
+                      "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  47,
+                                  48,
+                                  49,
+                                  50,
+                                  51,
+                                  52,
+                                  53,
+                                  54,
+                                  55,
+                                  56,
+                                  57,
+                                  58,
+                                  59,
+                                  60,
+                                  61,
+                                  62,
+                                  63,
+                                  64,
+                                  65,
+                                  66,
+                                  67,
+                                  68,
+                                  69,
+                                  70,
+                                  71,
+                                  72,
+                                  73,
+                                  74,
+                                  75,
+                                  76,
+                                  77,
+                                  78,
+                                  79,
+                                  80,
+                                  81,
+                                  82,
+                                  83,
+                                  84,
+                                  85,
+                                  86,
+                                  87,
+                                  88,
+                                  89,
+                                  90,
+                                  91,
+                                  92,
+                                  93
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
                                   "join": {
@@ -139,74 +147,190 @@
                                         "left": {
                                           "join": {
                                             "left": {
-                                              "read": {
-                                                "common": {
-                                                  "direct": {}
-                                                },
-                                                "baseSchema": {
-                                                  "names": [
-                                                    "c_custkey",
-                                                    "c_name",
-                                                    "c_address",
-                                                    "c_nationkey",
-                                                    "c_phone",
-                                                    "c_acctbal",
-                                                    "c_mktsegment",
-                                                    "c_comment"
-                                                  ],
-                                                  "struct": {
-                                                    "types": [
-                                                      {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
+                                              "join": {
+                                                "left": {
+                                                  "read": {
+                                                    "common": {
+                                                      "direct": {}
+                                                    },
+                                                    "baseSchema": {
+                                                      "names": [
+                                                        "c_custkey",
+                                                        "c_name",
+                                                        "c_address",
+                                                        "c_nationkey",
+                                                        "c_phone",
+                                                        "c_acctbal",
+                                                        "c_mktsegment",
+                                                        "c_comment"
+                                                      ],
+                                                      "struct": {
+                                                        "types": [
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
                                                       }
-                                                    ],
-                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                    },
+                                                    "namedTable": {
+                                                      "names": [
+                                                        "customer"
+                                                      ]
+                                                    }
                                                   }
                                                 },
-                                                "namedTable": {
-                                                  "names": [
-                                                    "customer"
-                                                  ]
-                                                }
+                                                "right": {
+                                                  "read": {
+                                                    "common": {
+                                                      "direct": {}
+                                                    },
+                                                    "baseSchema": {
+                                                      "names": [
+                                                        "o_orderkey",
+                                                        "o_custkey",
+                                                        "o_orderstatus",
+                                                        "o_totalprice",
+                                                        "o_orderdate",
+                                                        "o_orderpriority",
+                                                        "o_clerk",
+                                                        "o_shippriority",
+                                                        "o_comment"
+                                                      ],
+                                                      "struct": {
+                                                        "types": [
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "date": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                      }
+                                                    },
+                                                    "namedTable": {
+                                                      "names": [
+                                                        "orders"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "expression": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {}
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 9
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "JOIN_TYPE_INNER"
                                               }
                                             },
                                             "right": {
@@ -216,63 +340,111 @@
                                                 },
                                                 "baseSchema": {
                                                   "names": [
-                                                    "o_orderkey",
-                                                    "o_custkey",
-                                                    "o_orderstatus",
-                                                    "o_totalprice",
-                                                    "o_orderdate",
-                                                    "o_orderpriority",
-                                                    "o_clerk",
-                                                    "o_shippriority",
-                                                    "o_comment"
+                                                    "l_orderkey",
+                                                    "l_partkey",
+                                                    "l_suppkey",
+                                                    "l_linenumber",
+                                                    "l_quantity",
+                                                    "l_extendedprice",
+                                                    "l_discount",
+                                                    "l_tax",
+                                                    "l_returnflag",
+                                                    "l_linestatus",
+                                                    "l_shipdate",
+                                                    "l_commitdate",
+                                                    "l_receiptdate",
+                                                    "l_shipinstruct",
+                                                    "l_shipmode",
+                                                    "l_comment"
                                                   ],
                                                   "struct": {
                                                     "types": [
                                                       {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
                                                       {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
                                                       {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
                                                       {
                                                         "decimal": {
                                                           "scale": 2,
                                                           "precision": 15,
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
                                                       {
                                                         "date": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
                                                       {
                                                         "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
                                                       {
                                                         "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
                                                       {
                                                         "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       }
                                                     ],
@@ -281,7 +453,7 @@
                                                 },
                                                 "namedTable": {
                                                   "names": [
-                                                    "orders"
+                                                    "lineitem"
                                                   ]
                                                 }
                                               }
@@ -299,7 +471,9 @@
                                                     "value": {
                                                       "selection": {
                                                         "directReference": {
-                                                          "structField": {}
+                                                          "structField": {
+                                                            "field": 17
+                                                          }
                                                         },
                                                         "rootReference": {}
                                                       }
@@ -310,7 +484,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 9
+                                                            "field": 8
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -330,111 +504,51 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "l_orderkey",
-                                                "l_partkey",
-                                                "l_suppkey",
-                                                "l_linenumber",
-                                                "l_quantity",
-                                                "l_extendedprice",
-                                                "l_discount",
-                                                "l_tax",
-                                                "l_returnflag",
-                                                "l_linestatus",
-                                                "l_shipdate",
-                                                "l_commitdate",
-                                                "l_receiptdate",
-                                                "l_shipinstruct",
-                                                "l_shipmode",
-                                                "l_comment"
+                                                "s_suppkey",
+                                                "s_name",
+                                                "s_address",
+                                                "s_nationkey",
+                                                "s_phone",
+                                                "s_acctbal",
+                                                "s_comment"
                                               ],
                                               "struct": {
                                                 "types": [
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "decimal": {
                                                       "scale": 2,
                                                       "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   }
                                                 ],
@@ -443,7 +557,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "lineitem"
+                                                "supplier"
                                               ]
                                             }
                                           }
@@ -462,7 +576,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 17
+                                                        "field": 19
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -474,7 +588,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 8
+                                                        "field": 33
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -494,13 +608,10 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "s_suppkey",
-                                            "s_name",
-                                            "s_address",
-                                            "s_nationkey",
-                                            "s_phone",
-                                            "s_acctbal",
-                                            "s_comment"
+                                            "n_nationkey",
+                                            "n_name",
+                                            "n_regionkey",
+                                            "n_comment"
                                           ],
                                           "struct": {
                                             "types": [
@@ -515,24 +626,7 @@
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
                                                 "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -547,14 +641,14 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "supplier"
+                                            "nation"
                                           ]
                                         }
                                       }
                                     },
                                     "expression": {
                                       "scalarFunction": {
-                                        "functionReference": 1,
+                                        "functionReference": 2,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_NULLABLE"
@@ -563,25 +657,77 @@
                                         "arguments": [
                                           {
                                             "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 19
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
                                                   }
                                                 },
-                                                "rootReference": {}
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 3
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 36
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
                                               }
                                             }
                                           },
                                           {
                                             "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 33
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
                                                   }
                                                 },
-                                                "rootReference": {}
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 36
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 40
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
                                               }
                                             }
                                           }
@@ -598,10 +744,9 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "n_nationkey",
-                                        "n_name",
-                                        "n_regionkey",
-                                        "n_comment"
+                                        "r_regionkey",
+                                        "r_name",
+                                        "r_comment"
                                       ],
                                       "struct": {
                                         "types": [
@@ -616,11 +761,6 @@
                                             }
                                           },
                                           {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
                                             "string": {
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
@@ -631,12 +771,533 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "nation"
+                                        "region"
                                       ]
                                     }
                                   }
                                 },
                                 "expression": {
+                                  "scalarFunction": {
+                                    "functionReference": 1,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 42
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 44
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "JOIN_TYPE_INNER"
+                              }
+                            },
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 25
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 26
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 27
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 28
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 29
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 30
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 31
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 32
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 33
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 34
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 35
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 36
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 37
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 38
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 39
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 40
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 41
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 42
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 43
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 44
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 45
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 46
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 2,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
                                   "scalarFunction": {
                                     "functionReference": 2,
                                     "outputType": {
@@ -660,7 +1321,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 3
+                                                        "field": 45
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -669,13 +1330,8 @@
                                               },
                                               {
                                                 "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 36
-                                                      }
-                                                    },
-                                                    "rootReference": {}
+                                                  "literal": {
+                                                    "string": "ASIA"
                                                   }
                                                 }
                                               }
@@ -686,7 +1342,7 @@
                                       {
                                         "value": {
                                           "scalarFunction": {
-                                            "functionReference": 1,
+                                            "functionReference": 3,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_NULLABLE"
@@ -698,7 +1354,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 36
+                                                        "field": 12
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -707,13 +1363,8 @@
                                               },
                                               {
                                                 "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 40
-                                                      }
-                                                    },
-                                                    "rootReference": {}
+                                                  "literal": {
+                                                    "string": "1994-01-01"
                                                   }
                                                 }
                                               }
@@ -723,497 +1374,49 @@
                                       }
                                     ]
                                   }
-                                },
-                                "type": "JOIN_TYPE_INNER"
-                              }
-                            },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "r_regionkey",
-                                    "r_name",
-                                    "r_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
+                                }
+                              },
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 4,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
                                       {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 12
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
                                         }
                                       },
                                       {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
+                                        "value": {
+                                          "literal": {
+                                            "string": "1995-01-01"
+                                          }
                                         }
                                       }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
+                                    ]
                                   }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "region"
-                                  ]
                                 }
                               }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 42
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 44
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
-                        },
-                        "expressions": [
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 2
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 3
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 6
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 7
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 8
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 9
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 10
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 11
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 13
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 14
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 15
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 16
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 17
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 18
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 19
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 20
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 21
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 22
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 23
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 24
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 25
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 26
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 27
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 28
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 29
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 30
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 31
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 32
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 33
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 34
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 35
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 36
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 37
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 38
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 39
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 40
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
+                        }
+                      }
+                    },
+                    "groupings": [
+                      {
+                        "groupingExpressions": [
                           {
                             "selection": {
                               "directReference": {
@@ -1223,292 +1426,121 @@
                               },
                               "rootReference": {}
                             }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 42
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 43
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 44
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 45
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 46
-                                }
-                              },
-                              "rootReference": {}
-                            }
                           }
                         ]
                       }
-                    },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 2,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 2,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 1,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 45
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "literal": {
-                                                "string": "ASIA"
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 3,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 12
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "literal": {
-                                                "string": "1994-01-01"
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 4,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 12
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "literal": {
-                                        "string": "1995-01-01"
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  }
-                },
-                "groupings": [
-                  {
-                    "groupingExpressions": [
+                    ],
+                    "measures": [
                       {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 41
+                        "measure": {
+                          "functionReference": 5,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
                             }
                           },
-                          "rootReference": {}
+                          "arguments": [
+                            {
+                              "value": {
+                                "scalarFunction": {
+                                  "functionReference": 6,
+                                  "outputType": {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 22
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "value": {
+                                        "scalarFunction": {
+                                          "functionReference": 7,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "cast": {
+                                                  "type": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "input": {
+                                                    "literal": {
+                                                      "i8": 1
+                                                    }
+                                                  },
+                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 23
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     ]
                   }
-                ],
-                "measures": [
+                },
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 5,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "scalarFunction": {
-                              "functionReference": 6,
-                              "outputType": {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "value": {
-                                    "selection": {
-                                      "directReference": {
-                                        "structField": {
-                                          "field": 22
-                                        }
-                                      },
-                                      "rootReference": {}
-                                    }
-                                  }
-                                },
-                                {
-                                  "value": {
-                                    "scalarFunction": {
-                                      "functionReference": 7,
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "cast": {
-                                              "type": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "i8": 1
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 23
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
@@ -61,372 +61,393 @@
     {
       "root": {
         "input": {
-          "aggregate": {
-            "input": {
-              "filter": {
-                "input": {
-                  "read": {
-                    "common": {
-                      "direct": {}
-                    },
-                    "baseSchema": {
-                      "names": [
-                        "l_orderkey",
-                        "l_partkey",
-                        "l_suppkey",
-                        "l_linenumber",
-                        "l_quantity",
-                        "l_extendedprice",
-                        "l_discount",
-                        "l_tax",
-                        "l_returnflag",
-                        "l_linestatus",
-                        "l_shipdate",
-                        "l_commitdate",
-                        "l_receiptdate",
-                        "l_shipinstruct",
-                        "l_shipmode",
-                        "l_comment"
-                      ],
-                      "struct": {
-                        "types": [
-                          {
-                            "i64": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "i64": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "i64": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "i64": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 15,
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 15,
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 15,
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 15,
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "string": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "string": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "date": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "date": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "date": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "string": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "string": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          {
-                            "string": {
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          }
-                        ],
-                        "nullability": "NULLABILITY_REQUIRED"
-                      }
-                    },
-                    "namedTable": {
-                      "names": [
-                        "lineitem"
-                      ]
-                    }
-                  }
-                },
-                "condition": {
-                  "scalarFunction": {
-                    "functionReference": 1,
-                    "outputType": {
-                      "bool": {
-                        "nullability": "NULLABILITY_NULLABLE"
-                      }
-                    },
-                    "arguments": [
-                      {
-                        "value": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 2,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 10
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "1994-01-01"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 10
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "1995-01-01"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 4,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 6
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "literal": {
-                                            "fp64": 0.05
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "literal": {
-                                            "fp64": 0.07
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      },
-                      {
-                        "value": {
-                          "scalarFunction": {
-                            "functionReference": 3,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 4
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "literal": {
-                                    "i8": 24
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  1
+                ]
               }
             },
-            "groupings": [
-              {}
-            ],
-            "measures": [
-              {
-                "measure": {
-                  "functionReference": 5,
-                  "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                  "outputType": {
-                    "decimal": {
-                      "scale": 2,
-                      "precision": 38,
-                      "nullability": "NULLABILITY_NULLABLE"
-                    }
-                  },
-                  "arguments": [
-                    {
-                      "value": {
-                        "scalarFunction": {
-                          "functionReference": 6,
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 15,
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          "arguments": [
-                            {
-                              "value": {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 5
-                                    }
-                                  },
-                                  "rootReference": {}
+            "input": {
+              "aggregate": {
+                "input": {
+                  "filter": {
+                    "input": {
+                      "read": {
+                        "common": {
+                          "direct": {}
+                        },
+                        "baseSchema": {
+                          "names": [
+                            "l_orderkey",
+                            "l_partkey",
+                            "l_suppkey",
+                            "l_linenumber",
+                            "l_quantity",
+                            "l_extendedprice",
+                            "l_discount",
+                            "l_tax",
+                            "l_returnflag",
+                            "l_linestatus",
+                            "l_shipdate",
+                            "l_commitdate",
+                            "l_receiptdate",
+                            "l_shipinstruct",
+                            "l_shipmode",
+                            "l_comment"
+                          ],
+                          "struct": {
+                            "types": [
+                              {
+                                "i64": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "i64": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "i64": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "i64": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "date": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "date": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "date": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
                                 }
                               }
-                            },
-                            {
-                              "value": {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 6
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              }
-                            }
+                            ],
+                            "nullability": "NULLABILITY_REQUIRED"
+                          }
+                        },
+                        "namedTable": {
+                          "names": [
+                            "lineitem"
                           ]
                         }
                       }
+                    },
+                    "condition": {
+                      "scalarFunction": {
+                        "functionReference": 1,
+                        "outputType": {
+                          "bool": {
+                            "nullability": "NULLABILITY_NULLABLE"
+                          }
+                        },
+                        "arguments": [
+                          {
+                            "value": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 2,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 10
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "1994-01-01"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 10
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "1995-01-01"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 4,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 6
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "literal": {
+                                                "fp64": 0.05
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "literal": {
+                                                "fp64": 0.07
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "value": {
+                              "scalarFunction": {
+                                "functionReference": 3,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 4
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "literal": {
+                                        "i8": 24
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
                     }
-                  ]
+                  }
+                },
+                "groupings": [
+                  {}
+                ],
+                "measures": [
+                  {
+                    "measure": {
+                      "functionReference": 5,
+                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                      "outputType": {
+                        "decimal": {
+                          "scale": 2,
+                          "precision": 38,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "scalarFunction": {
+                              "functionReference": 6,
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  }
+                                },
+                                {
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "expressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {}
+                  },
+                  "rootReference": {}
                 }
               }
             ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
@@ -81,27 +81,37 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      4,
+                      5,
+                      6,
+                      7
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "project": {
-                        "common": {
-                          "emit": {
-                            "outputMapping": [
-                              48,
-                              49,
-                              50,
-                              51,
-                              52,
-                              53,
-                              54
-                            ]
-                          }
-                        },
+                      "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  48,
+                                  49,
+                                  50,
+                                  51,
+                                  52,
+                                  53,
+                                  54
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
                                   "join": {
@@ -110,68 +120,232 @@
                                         "left": {
                                           "join": {
                                             "left": {
-                                              "read": {
-                                                "common": {
-                                                  "direct": {}
-                                                },
-                                                "baseSchema": {
-                                                  "names": [
-                                                    "s_suppkey",
-                                                    "s_name",
-                                                    "s_address",
-                                                    "s_nationkey",
-                                                    "s_phone",
-                                                    "s_acctbal",
-                                                    "s_comment"
-                                                  ],
-                                                  "struct": {
-                                                    "types": [
-                                                      {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i32": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
+                                              "join": {
+                                                "left": {
+                                                  "read": {
+                                                    "common": {
+                                                      "direct": {}
+                                                    },
+                                                    "baseSchema": {
+                                                      "names": [
+                                                        "s_suppkey",
+                                                        "s_name",
+                                                        "s_address",
+                                                        "s_nationkey",
+                                                        "s_phone",
+                                                        "s_acctbal",
+                                                        "s_comment"
+                                                      ],
+                                                      "struct": {
+                                                        "types": [
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
                                                       }
-                                                    ],
-                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                    },
+                                                    "namedTable": {
+                                                      "names": [
+                                                        "supplier"
+                                                      ]
+                                                    }
                                                   }
                                                 },
-                                                "namedTable": {
-                                                  "names": [
-                                                    "supplier"
-                                                  ]
-                                                }
+                                                "right": {
+                                                  "read": {
+                                                    "common": {
+                                                      "direct": {}
+                                                    },
+                                                    "baseSchema": {
+                                                      "names": [
+                                                        "l_orderkey",
+                                                        "l_partkey",
+                                                        "l_suppkey",
+                                                        "l_linenumber",
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_tax",
+                                                        "l_returnflag",
+                                                        "l_linestatus",
+                                                        "l_shipdate",
+                                                        "l_commitdate",
+                                                        "l_receiptdate",
+                                                        "l_shipinstruct",
+                                                        "l_shipmode",
+                                                        "l_comment"
+                                                      ],
+                                                      "struct": {
+                                                        "types": [
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "date": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "date": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "date": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                      }
+                                                    },
+                                                    "namedTable": {
+                                                      "names": [
+                                                        "lineitem"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "expression": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {}
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 9
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "JOIN_TYPE_INNER"
                                               }
                                             },
                                             "right": {
@@ -181,111 +355,63 @@
                                                 },
                                                 "baseSchema": {
                                                   "names": [
-                                                    "l_orderkey",
-                                                    "l_partkey",
-                                                    "l_suppkey",
-                                                    "l_linenumber",
-                                                    "l_quantity",
-                                                    "l_extendedprice",
-                                                    "l_discount",
-                                                    "l_tax",
-                                                    "l_returnflag",
-                                                    "l_linestatus",
-                                                    "l_shipdate",
-                                                    "l_commitdate",
-                                                    "l_receiptdate",
-                                                    "l_shipinstruct",
-                                                    "l_shipmode",
-                                                    "l_comment"
+                                                    "o_orderkey",
+                                                    "o_custkey",
+                                                    "o_orderstatus",
+                                                    "o_totalprice",
+                                                    "o_orderdate",
+                                                    "o_orderpriority",
+                                                    "o_clerk",
+                                                    "o_shippriority",
+                                                    "o_comment"
                                                   ],
                                                   "struct": {
                                                     "types": [
                                                       {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
                                                         "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
                                                         "date": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "date": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "date": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
                                                         "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
                                                         "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
                                                         "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       }
                                                     ],
@@ -294,7 +420,7 @@
                                                 },
                                                 "namedTable": {
                                                   "names": [
-                                                    "lineitem"
+                                                    "orders"
                                                   ]
                                                 }
                                               }
@@ -312,7 +438,9 @@
                                                     "value": {
                                                       "selection": {
                                                         "directReference": {
-                                                          "structField": {}
+                                                          "structField": {
+                                                            "field": 23
+                                                          }
                                                         },
                                                         "rootReference": {}
                                                       }
@@ -323,7 +451,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 9
+                                                            "field": 7
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -343,20 +471,29 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "o_orderkey",
-                                                "o_custkey",
-                                                "o_orderstatus",
-                                                "o_totalprice",
-                                                "o_orderdate",
-                                                "o_orderpriority",
-                                                "o_clerk",
-                                                "o_shippriority",
-                                                "o_comment"
+                                                "c_custkey",
+                                                "c_name",
+                                                "c_address",
+                                                "c_nationkey",
+                                                "c_phone",
+                                                "c_acctbal",
+                                                "c_mktsegment",
+                                                "c_comment"
                                               ],
                                               "struct": {
                                                 "types": [
                                                   {
                                                     "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
@@ -378,22 +515,7 @@
                                                     }
                                                   },
                                                   {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
@@ -408,7 +530,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "orders"
+                                                "customer"
                                               ]
                                             }
                                           }
@@ -427,7 +549,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 23
+                                                        "field": 32
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -439,7 +561,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 7
+                                                        "field": 24
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -459,14 +581,10 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "c_custkey",
-                                            "c_name",
-                                            "c_address",
-                                            "c_nationkey",
-                                            "c_phone",
-                                            "c_acctbal",
-                                            "c_mktsegment",
-                                            "c_comment"
+                                            "n_nationkey",
+                                            "n_name",
+                                            "n_regionkey",
+                                            "n_comment"
                                           ],
                                           "struct": {
                                             "types": [
@@ -481,29 +599,7 @@
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
                                                 "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -518,7 +614,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "customer"
+                                            "nation"
                                           ]
                                         }
                                       }
@@ -537,7 +633,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 32
+                                                    "field": 3
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -549,7 +645,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 24
+                                                    "field": 40
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -621,7 +717,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 3
+                                                "field": 35
                                               }
                                             },
                                             "rootReference": {}
@@ -632,9 +728,7 @@
                                         "value": {
                                           "selection": {
                                             "directReference": {
-                                              "structField": {
-                                                "field": 40
-                                              }
+                                              "structField": {}
                                             },
                                             "rootReference": {}
                                           }
@@ -646,95 +740,405 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "n_nationkey",
-                                    "n_name",
-                                    "n_regionkey",
-                                    "n_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 41
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "cast": {
+                                  "type": {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "input": {
+                                    "scalarFunction": {
+                                      "functionReference": 2,
+                                      "outputType": {
                                         "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
+                                          "nullability": "NULLABILITY_NULLABLE"
                                         }
                                       },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
+                                      "arguments": [
+                                        {
+                                          "enum": "YEAR"
+                                        },
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 17
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          }
                                         }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
+                                      ]
+                                    }
+                                  },
+                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                }
+                              },
+                              {
+                                "scalarFunction": {
+                                  "functionReference": 3,
+                                  "outputType": {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 12
+                                            }
+                                          },
+                                          "rootReference": {}
                                         }
                                       }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "nation"
+                                    },
+                                    {
+                                      "value": {
+                                        "scalarFunction": {
+                                          "functionReference": 4,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "cast": {
+                                                  "type": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "input": {
+                                                    "literal": {
+                                                      "i8": 1
+                                                    }
+                                                  },
+                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 13
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
                                   ]
                                 }
                               }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 35
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {}
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "type": "JOIN_TYPE_INNER"
+                            ]
                           }
                         },
-                        "expressions": [
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 5,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 6,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 5,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 45
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "literal": {
+                                                            "string": "FRANCE"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 41
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "literal": {
+                                                            "string": "GERMANY"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 5,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 45
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "literal": {
+                                                            "string": "GERMANY"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 41
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "literal": {
+                                                            "string": "FRANCE"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 7,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 17
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "string": "1995-01-01"
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "string": "1996-12-31"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "groupings": [
+                      {
+                        "groupingExpressions": [
                           {
                             "selection": {
                               "directReference": {
-                                "structField": {
-                                  "field": 41
-                                }
+                                "structField": {}
                               },
                               "rootReference": {}
                             }
@@ -753,433 +1157,83 @@
                             "selection": {
                               "directReference": {
                                 "structField": {
-                                  "field": 17
+                                  "field": 5
                                 }
                               },
                               "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 13
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "cast": {
-                              "type": {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "input": {
-                                "scalarFunction": {
-                                  "functionReference": 2,
-                                  "outputType": {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "enum": "YEAR"
-                                    },
-                                    {
-                                      "value": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 17
-                                            }
-                                          },
-                                          "rootReference": {}
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                            }
-                          },
-                          {
-                            "scalarFunction": {
-                              "functionReference": 3,
-                              "outputType": {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "value": {
-                                    "selection": {
-                                      "directReference": {
-                                        "structField": {
-                                          "field": 12
-                                        }
-                                      },
-                                      "rootReference": {}
-                                    }
-                                  }
-                                },
-                                {
-                                  "value": {
-                                    "scalarFunction": {
-                                      "functionReference": 4,
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "cast": {
-                                              "type": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "input": {
-                                                "literal": {
-                                                  "i8": 1
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 13
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
                             }
                           }
                         ]
                       }
-                    },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 5,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 6,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 5,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 1,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 45
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "literal": {
-                                                        "string": "FRANCE"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 1,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 41
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "literal": {
-                                                        "string": "GERMANY"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
+                    ],
+                    "measures": [
+                      {
+                        "measure": {
+                          "functionReference": 8,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 5,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 1,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 45
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "literal": {
-                                                        "string": "GERMANY"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 1,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 41
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "literal": {
-                                                        "string": "FRANCE"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                ]
+                                  "rootReference": {}
+                                }
                               }
                             }
-                          },
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 7,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 17
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "literal": {
-                                        "string": "1995-01-01"
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "literal": {
-                                        "string": "1996-12-31"
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  }
-                },
-                "groupings": [
-                  {
-                    "groupingExpressions": [
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {}
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 1
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 5
-                            }
-                          },
-                          "rootReference": {}
+                          ]
                         }
                       }
                     ]
                   }
-                ],
-                "measures": [
+                },
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 8,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 6
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 2
                         }
-                      ]
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 3
+                        }
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
@@ -103,41 +103,50 @@
                       }
                     },
                     "input": {
-                      "aggregate": {
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              3,
+                              4,
+                              5
+                            ]
+                          }
+                        },
                         "input": {
-                          "project": {
-                            "common": {
-                              "emit": {
-                                "outputMapping": [
-                                  6,
-                                  7,
-                                  8,
-                                  9,
-                                  10,
-                                  11,
-                                  12
-                                ]
-                              }
-                            },
+                          "aggregate": {
                             "input": {
-                              "filter": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      6,
+                                      7,
+                                      8,
+                                      9,
+                                      10,
+                                      11,
+                                      12
+                                    ]
+                                  }
+                                },
                                 "input": {
-                                  "project": {
-                                    "common": {
-                                      "emit": {
-                                        "outputMapping": [
-                                          60,
-                                          61,
-                                          62,
-                                          63,
-                                          64,
-                                          65
-                                        ]
-                                      }
-                                    },
+                                  "filter": {
                                     "input": {
-                                      "join": {
-                                        "left": {
+                                      "project": {
+                                        "common": {
+                                          "emit": {
+                                            "outputMapping": [
+                                              60,
+                                              61,
+                                              62,
+                                              63,
+                                              64,
+                                              65
+                                            ]
+                                          }
+                                        },
+                                        "input": {
                                           "join": {
                                             "left": {
                                               "join": {
@@ -150,80 +159,244 @@
                                                             "left": {
                                                               "join": {
                                                                 "left": {
-                                                                  "read": {
-                                                                    "common": {
-                                                                      "direct": {}
-                                                                    },
-                                                                    "baseSchema": {
-                                                                      "names": [
-                                                                        "p_partkey",
-                                                                        "p_name",
-                                                                        "p_mfgr",
-                                                                        "p_brand",
-                                                                        "p_type",
-                                                                        "p_size",
-                                                                        "p_container",
-                                                                        "p_retailprice",
-                                                                        "p_comment"
-                                                                      ],
-                                                                      "struct": {
-                                                                        "types": [
-                                                                          {
-                                                                            "i32": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "i32": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "decimal": {
-                                                                              "scale": 2,
-                                                                              "precision": 15,
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                                            }
+                                                                  "join": {
+                                                                    "left": {
+                                                                      "read": {
+                                                                        "common": {
+                                                                          "direct": {}
+                                                                        },
+                                                                        "baseSchema": {
+                                                                          "names": [
+                                                                            "p_partkey",
+                                                                            "p_name",
+                                                                            "p_mfgr",
+                                                                            "p_brand",
+                                                                            "p_type",
+                                                                            "p_size",
+                                                                            "p_container",
+                                                                            "p_retailprice",
+                                                                            "p_comment"
+                                                                          ],
+                                                                          "struct": {
+                                                                            "types": [
+                                                                              {
+                                                                                "i32": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "i32": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "decimal": {
+                                                                                  "scale": 2,
+                                                                                  "precision": 15,
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                                }
+                                                                              }
+                                                                            ],
+                                                                            "nullability": "NULLABILITY_REQUIRED"
                                                                           }
-                                                                        ],
-                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                        },
+                                                                        "namedTable": {
+                                                                          "names": [
+                                                                            "part"
+                                                                          ]
+                                                                        }
                                                                       }
                                                                     },
-                                                                    "namedTable": {
-                                                                      "names": [
-                                                                        "part"
-                                                                      ]
-                                                                    }
+                                                                    "right": {
+                                                                      "read": {
+                                                                        "common": {
+                                                                          "direct": {}
+                                                                        },
+                                                                        "baseSchema": {
+                                                                          "names": [
+                                                                            "l_orderkey",
+                                                                            "l_partkey",
+                                                                            "l_suppkey",
+                                                                            "l_linenumber",
+                                                                            "l_quantity",
+                                                                            "l_extendedprice",
+                                                                            "l_discount",
+                                                                            "l_tax",
+                                                                            "l_returnflag",
+                                                                            "l_linestatus",
+                                                                            "l_shipdate",
+                                                                            "l_commitdate",
+                                                                            "l_receiptdate",
+                                                                            "l_shipinstruct",
+                                                                            "l_shipmode",
+                                                                            "l_comment"
+                                                                          ],
+                                                                          "struct": {
+                                                                            "types": [
+                                                                              {
+                                                                                "i64": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "i64": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "i64": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "i64": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "decimal": {
+                                                                                  "scale": 2,
+                                                                                  "precision": 15,
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "decimal": {
+                                                                                  "scale": 2,
+                                                                                  "precision": 15,
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "decimal": {
+                                                                                  "scale": 2,
+                                                                                  "precision": 15,
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "decimal": {
+                                                                                  "scale": 2,
+                                                                                  "precision": 15,
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "date": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "date": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "date": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              },
+                                                                              {
+                                                                                "string": {
+                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                              }
+                                                                            ],
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        "namedTable": {
+                                                                          "names": [
+                                                                            "lineitem"
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "expression": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 1,
+                                                                        "outputType": {
+                                                                          "bool": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "selection": {
+                                                                                "directReference": {
+                                                                                  "structField": {}
+                                                                                },
+                                                                                "rootReference": {}
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "selection": {
+                                                                                "directReference": {
+                                                                                  "structField": {
+                                                                                    "field": 10
+                                                                                  }
+                                                                                },
+                                                                                "rootReference": {}
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    "type": "JOIN_TYPE_INNER"
                                                                   }
                                                                 },
                                                                 "right": {
@@ -233,111 +406,51 @@
                                                                     },
                                                                     "baseSchema": {
                                                                       "names": [
-                                                                        "l_orderkey",
-                                                                        "l_partkey",
-                                                                        "l_suppkey",
-                                                                        "l_linenumber",
-                                                                        "l_quantity",
-                                                                        "l_extendedprice",
-                                                                        "l_discount",
-                                                                        "l_tax",
-                                                                        "l_returnflag",
-                                                                        "l_linestatus",
-                                                                        "l_shipdate",
-                                                                        "l_commitdate",
-                                                                        "l_receiptdate",
-                                                                        "l_shipinstruct",
-                                                                        "l_shipmode",
-                                                                        "l_comment"
+                                                                        "s_suppkey",
+                                                                        "s_name",
+                                                                        "s_address",
+                                                                        "s_nationkey",
+                                                                        "s_phone",
+                                                                        "s_acctbal",
+                                                                        "s_comment"
                                                                       ],
                                                                       "struct": {
                                                                         "types": [
                                                                           {
-                                                                            "i64": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            "i32": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
                                                                             }
                                                                           },
                                                                           {
-                                                                            "i64": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
                                                                             }
                                                                           },
                                                                           {
-                                                                            "i64": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
                                                                             }
                                                                           },
                                                                           {
-                                                                            "i64": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            "i32": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "string": {
+                                                                              "nullability": "NULLABILITY_REQUIRED"
                                                                             }
                                                                           },
                                                                           {
                                                                             "decimal": {
                                                                               "scale": 2,
                                                                               "precision": 15,
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "decimal": {
-                                                                              "scale": 2,
-                                                                              "precision": 15,
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "decimal": {
-                                                                              "scale": 2,
-                                                                              "precision": 15,
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "decimal": {
-                                                                              "scale": 2,
-                                                                              "precision": 15,
-                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                              "nullability": "NULLABILITY_REQUIRED"
                                                                             }
                                                                           },
                                                                           {
                                                                             "string": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "date": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "date": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "date": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "string": {
-                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                              "nullability": "NULLABILITY_REQUIRED"
                                                                             }
                                                                           }
                                                                         ],
@@ -346,7 +459,7 @@
                                                                     },
                                                                     "namedTable": {
                                                                       "names": [
-                                                                        "lineitem"
+                                                                        "supplier"
                                                                       ]
                                                                     }
                                                                   }
@@ -364,7 +477,9 @@
                                                                         "value": {
                                                                           "selection": {
                                                                             "directReference": {
-                                                                              "structField": {}
+                                                                              "structField": {
+                                                                                "field": 25
+                                                                              }
                                                                             },
                                                                             "rootReference": {}
                                                                           }
@@ -375,7 +490,7 @@
                                                                           "selection": {
                                                                             "directReference": {
                                                                               "structField": {
-                                                                                "field": 10
+                                                                                "field": 11
                                                                               }
                                                                             },
                                                                             "rootReference": {}
@@ -395,28 +510,20 @@
                                                                 },
                                                                 "baseSchema": {
                                                                   "names": [
-                                                                    "s_suppkey",
-                                                                    "s_name",
-                                                                    "s_address",
-                                                                    "s_nationkey",
-                                                                    "s_phone",
-                                                                    "s_acctbal",
-                                                                    "s_comment"
+                                                                    "o_orderkey",
+                                                                    "o_custkey",
+                                                                    "o_orderstatus",
+                                                                    "o_totalprice",
+                                                                    "o_orderdate",
+                                                                    "o_orderpriority",
+                                                                    "o_clerk",
+                                                                    "o_shippriority",
+                                                                    "o_comment"
                                                                   ],
                                                                   "struct": {
                                                                     "types": [
                                                                       {
                                                                         "i32": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
-                                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "string": {
                                                                           "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       },
@@ -438,6 +545,26 @@
                                                                         }
                                                                       },
                                                                       {
+                                                                        "date": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "string": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "string": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                        }
+                                                                      },
+                                                                      {
+                                                                        "i32": {
+                                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                                        }
+                                                                      },
+                                                                      {
                                                                         "string": {
                                                                           "nullability": "NULLABILITY_REQUIRED"
                                                                         }
@@ -448,7 +575,7 @@
                                                                 },
                                                                 "namedTable": {
                                                                   "names": [
-                                                                    "supplier"
+                                                                    "orders"
                                                                   ]
                                                                 }
                                                               }
@@ -467,7 +594,7 @@
                                                                       "selection": {
                                                                         "directReference": {
                                                                           "structField": {
-                                                                            "field": 25
+                                                                            "field": 9
                                                                           }
                                                                         },
                                                                         "rootReference": {}
@@ -479,7 +606,7 @@
                                                                       "selection": {
                                                                         "directReference": {
                                                                           "structField": {
-                                                                            "field": 11
+                                                                            "field": 32
                                                                           }
                                                                         },
                                                                         "rootReference": {}
@@ -499,20 +626,29 @@
                                                             },
                                                             "baseSchema": {
                                                               "names": [
-                                                                "o_orderkey",
-                                                                "o_custkey",
-                                                                "o_orderstatus",
-                                                                "o_totalprice",
-                                                                "o_orderdate",
-                                                                "o_orderpriority",
-                                                                "o_clerk",
-                                                                "o_shippriority",
-                                                                "o_comment"
+                                                                "c_custkey",
+                                                                "c_name",
+                                                                "c_address",
+                                                                "c_nationkey",
+                                                                "c_phone",
+                                                                "c_acctbal",
+                                                                "c_mktsegment",
+                                                                "c_comment"
                                                               ],
                                                               "struct": {
                                                                 "types": [
                                                                   {
                                                                     "i32": {
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "string": {
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "string": {
                                                                       "nullability": "NULLABILITY_REQUIRED"
                                                                     }
                                                                   },
@@ -534,22 +670,7 @@
                                                                     }
                                                                   },
                                                                   {
-                                                                    "date": {
-                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                    }
-                                                                  },
-                                                                  {
                                                                     "string": {
-                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "string": {
-                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "i32": {
                                                                       "nullability": "NULLABILITY_REQUIRED"
                                                                     }
                                                                   },
@@ -564,7 +685,7 @@
                                                             },
                                                             "namedTable": {
                                                               "names": [
-                                                                "orders"
+                                                                "customer"
                                                               ]
                                                             }
                                                           }
@@ -583,7 +704,7 @@
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 9
+                                                                        "field": 33
                                                                       }
                                                                     },
                                                                     "rootReference": {}
@@ -595,7 +716,7 @@
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 32
+                                                                        "field": 41
                                                                       }
                                                                     },
                                                                     "rootReference": {}
@@ -615,14 +736,10 @@
                                                         },
                                                         "baseSchema": {
                                                           "names": [
-                                                            "c_custkey",
-                                                            "c_name",
-                                                            "c_address",
-                                                            "c_nationkey",
-                                                            "c_phone",
-                                                            "c_acctbal",
-                                                            "c_mktsegment",
-                                                            "c_comment"
+                                                            "n_nationkey",
+                                                            "n_name",
+                                                            "n_regionkey",
+                                                            "n_comment"
                                                           ],
                                                           "struct": {
                                                             "types": [
@@ -637,29 +754,7 @@
                                                                 }
                                                               },
                                                               {
-                                                                "string": {
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              {
                                                                 "i32": {
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              {
-                                                                "string": {
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              {
-                                                                "decimal": {
-                                                                  "scale": 2,
-                                                                  "precision": 15,
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              {
-                                                                "string": {
                                                                   "nullability": "NULLABILITY_REQUIRED"
                                                                 }
                                                               },
@@ -674,7 +769,7 @@
                                                         },
                                                         "namedTable": {
                                                           "names": [
-                                                            "customer"
+                                                            "nation"
                                                           ]
                                                         }
                                                       }
@@ -693,7 +788,7 @@
                                                               "selection": {
                                                                 "directReference": {
                                                                   "structField": {
-                                                                    "field": 33
+                                                                    "field": 44
                                                                   }
                                                                 },
                                                                 "rootReference": {}
@@ -705,7 +800,7 @@
                                                               "selection": {
                                                                 "directReference": {
                                                                   "structField": {
-                                                                    "field": 41
+                                                                    "field": 49
                                                                   }
                                                                 },
                                                                 "rootReference": {}
@@ -725,10 +820,9 @@
                                                     },
                                                     "baseSchema": {
                                                       "names": [
-                                                        "n_nationkey",
-                                                        "n_name",
-                                                        "n_regionkey",
-                                                        "n_comment"
+                                                        "r_regionkey",
+                                                        "r_name",
+                                                        "r_comment"
                                                       ],
                                                       "struct": {
                                                         "types": [
@@ -743,11 +837,6 @@
                                                             }
                                                           },
                                                           {
-                                                            "i32": {
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          },
-                                                          {
                                                             "string": {
                                                               "nullability": "NULLABILITY_REQUIRED"
                                                             }
@@ -758,7 +847,7 @@
                                                     },
                                                     "namedTable": {
                                                       "names": [
-                                                        "nation"
+                                                        "region"
                                                       ]
                                                     }
                                                   }
@@ -777,7 +866,7 @@
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 44
+                                                                "field": 51
                                                               }
                                                             },
                                                             "rootReference": {}
@@ -789,7 +878,7 @@
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 49
+                                                                "field": 53
                                                               }
                                                             },
                                                             "rootReference": {}
@@ -809,9 +898,10 @@
                                                 },
                                                 "baseSchema": {
                                                   "names": [
-                                                    "r_regionkey",
-                                                    "r_name",
-                                                    "r_comment"
+                                                    "n_nationkey",
+                                                    "n_name",
+                                                    "n_regionkey",
+                                                    "n_comment"
                                                   ],
                                                   "struct": {
                                                     "types": [
@@ -826,6 +916,11 @@
                                                         }
                                                       },
                                                       {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
                                                         "string": {
                                                           "nullability": "NULLABILITY_REQUIRED"
                                                         }
@@ -836,7 +931,7 @@
                                                 },
                                                 "namedTable": {
                                                   "names": [
-                                                    "region"
+                                                    "nation"
                                                   ]
                                                 }
                                               }
@@ -855,7 +950,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 51
+                                                            "field": 28
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -866,9 +961,7 @@
                                                     "value": {
                                                       "selection": {
                                                         "directReference": {
-                                                          "structField": {
-                                                            "field": 53
-                                                          }
+                                                          "structField": {}
                                                         },
                                                         "rootReference": {}
                                                       }
@@ -880,186 +973,32 @@
                                             "type": "JOIN_TYPE_INNER"
                                           }
                                         },
-                                        "right": {
-                                          "read": {
-                                            "common": {
-                                              "direct": {}
-                                            },
-                                            "baseSchema": {
-                                              "names": [
-                                                "n_nationkey",
-                                                "n_name",
-                                                "n_regionkey",
-                                                "n_comment"
-                                              ],
-                                              "struct": {
-                                                "types": [
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  }
-                                                ],
-                                                "nullability": "NULLABILITY_REQUIRED"
-                                              }
-                                            },
-                                            "namedTable": {
-                                              "names": [
-                                                "nation"
-                                              ]
-                                            }
-                                          }
-                                        },
-                                        "expression": {
-                                          "scalarFunction": {
-                                            "functionReference": 1,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 28
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {}
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        },
-                                        "type": "JOIN_TYPE_INNER"
-                                      }
-                                    },
-                                    "expressions": [
-                                      {
-                                        "cast": {
-                                          "type": {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "input": {
-                                            "scalarFunction": {
-                                              "functionReference": 2,
-                                              "outputType": {
-                                                "i32": {
+                                        "expressions": [
+                                          {
+                                            "cast": {
+                                              "type": {
+                                                "string": {
                                                   "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
-                                              "arguments": [
-                                                {
-                                                  "enum": "YEAR"
-                                                },
-                                                {
-                                                  "value": {
-                                                    "selection": {
-                                                      "directReference": {
-                                                        "structField": {
-                                                          "field": 36
-                                                        }
-                                                      },
-                                                      "rootReference": {}
-                                                    }
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                        }
-                                      },
-                                      {
-                                        "scalarFunction": {
-                                          "functionReference": 3,
-                                          "outputType": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 14
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "value": {
+                                              "input": {
                                                 "scalarFunction": {
-                                                  "functionReference": 4,
+                                                  "functionReference": 2,
                                                   "outputType": {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
+                                                    "i32": {
                                                       "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   "arguments": [
                                                     {
-                                                      "value": {
-                                                        "cast": {
-                                                          "type": {
-                                                            "decimal": {
-                                                              "scale": 2,
-                                                              "precision": 15,
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "input": {
-                                                            "literal": {
-                                                              "i8": 1
-                                                            }
-                                                          },
-                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                        }
-                                                      }
+                                                      "enum": "YEAR"
                                                     },
                                                     {
                                                       "value": {
                                                         "selection": {
                                                           "directReference": {
                                                             "structField": {
-                                                              "field": 15
+                                                              "field": 36
                                                             }
                                                           },
                                                           "rootReference": {}
@@ -1068,360 +1007,270 @@
                                                     }
                                                   ]
                                                 }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 1
+                                              },
+                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
                                             }
                                           },
-                                          "rootReference": {}
-                                        }
-                                      },
-                                      {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 54
+                                          {
+                                            "scalarFunction": {
+                                              "functionReference": 3,
+                                              "outputType": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 14
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "scalarFunction": {
+                                                      "functionReference": 4,
+                                                      "outputType": {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "arguments": [
+                                                        {
+                                                          "value": {
+                                                            "cast": {
+                                                              "type": {
+                                                                "decimal": {
+                                                                  "scale": 2,
+                                                                  "precision": 15,
+                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                              },
+                                                              "input": {
+                                                                "literal": {
+                                                                  "i8": 1
+                                                                }
+                                                              },
+                                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 15
+                                                                }
+                                                              },
+                                                              "rootReference": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              ]
                                             }
                                           },
-                                          "rootReference": {}
-                                        }
-                                      },
-                                      {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 36
+                                          {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 1
+                                                }
+                                              },
+                                              "rootReference": {}
                                             }
                                           },
-                                          "rootReference": {}
-                                        }
-                                      },
-                                      {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 4
+                                          {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 54
+                                                }
+                                              },
+                                              "rootReference": {}
                                             }
                                           },
-                                          "rootReference": {}
-                                        }
-                                      }
-                                    ]
-                                  }
-                                },
-                                "condition": {
-                                  "scalarFunction": {
-                                    "functionReference": 5,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
+                                          {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 36
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          },
+                                          {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 4
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        ]
                                       }
                                     },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 5,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 1,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 54
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "literal": {
-                                                            "string": "AMERICA"
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 6,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 36
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "literal": {
-                                                            "string": "1995-01-01"
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "literal": {
-                                                            "string": "1996-12-31"
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              }
-                                            ]
+                                    "condition": {
+                                      "scalarFunction": {
+                                        "functionReference": 5,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
                                           }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 1,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 4
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 5,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 1,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 54
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "literal": {
+                                                                "string": "AMERICA"
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
                                                       }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "ECONOMY ANODIZED STEEL"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              }
-                            },
-                            "expressions": [
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {}
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 1
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 2
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 3
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 4
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 5
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "ifThen": {
-                                  "ifs": [
-                                    {
-                                      "if": {
-                                        "scalarFunction": {
-                                          "functionReference": 1,
-                                          "outputType": {
-                                            "bool": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 2
                                                     }
                                                   },
-                                                  "rootReference": {}
-                                                }
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 6,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 36
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "literal": {
+                                                                "string": "1995-01-01"
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "literal": {
+                                                                "string": "1996-12-31"
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                ]
                                               }
-                                            },
-                                            {
-                                              "value": {
-                                                "literal": {
-                                                  "string": "BRAZIL"
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      "then": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 1
                                             }
                                           },
-                                          "rootReference": {}
-                                        }
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 4
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "ECONOMY ANODIZED STEEL"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
                                       }
                                     }
-                                  ],
-                                  "else": {
-                                    "literal": {
-                                      "i8": 0
-                                    }
                                   }
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "groupings": [
-                          {
-                            "groupingExpressions": [
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {}
-                                  },
-                                  "rootReference": {}
-                                }
-                              }
-                            ]
-                          }
-                        ],
-                        "measures": [
-                          {
-                            "measure": {
-                              "functionReference": 7,
-                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                              "outputType": {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 38,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "value": {
+                                },
+                                "expressions": [
+                                  {
                                     "selection": {
                                       "directReference": {
-                                        "structField": {
-                                          "field": 6
-                                        }
+                                        "structField": {}
                                       },
                                       "rootReference": {}
                                     }
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "measure": {
-                              "functionReference": 7,
-                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                              "outputType": {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 38,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "value": {
+                                  },
+                                  {
                                     "selection": {
                                       "directReference": {
                                         "structField": {
@@ -1430,9 +1279,203 @@
                                       },
                                       "rootReference": {}
                                     }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 2
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 3
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "ifThen": {
+                                      "ifs": [
+                                        {
+                                          "if": {
+                                            "scalarFunction": {
+                                              "functionReference": 1,
+                                              "outputType": {
+                                                "bool": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 2
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "literal": {
+                                                      "string": "BRAZIL"
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "then": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 1
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        }
+                                      ],
+                                      "else": {
+                                        "literal": {
+                                          "i8": 0
+                                        }
+                                      }
+                                    }
                                   }
+                                ]
+                              }
+                            },
+                            "groupings": [
+                              {
+                                "groupingExpressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  }
+                                ]
+                              }
+                            ],
+                            "measures": [
+                              {
+                                "measure": {
+                                  "functionReference": 7,
+                                  "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                  "outputType": {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 38,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 6
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      }
+                                    }
+                                  ]
                                 }
-                              ]
+                              },
+                              {
+                                "measure": {
+                                  "functionReference": 7,
+                                  "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                  "outputType": {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 38,
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 1
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
                             }
                           }
                         ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
@@ -78,24 +78,33 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      3,
+                      4,
+                      5
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "project": {
-                        "common": {
-                          "emit": {
-                            "outputMapping": [
-                              50,
-                              51,
-                              52,
-                              53
-                            ]
-                          }
-                        },
+                      "filter": {
                         "input": {
-                          "join": {
-                            "left": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  50,
+                                  51,
+                                  52,
+                                  53
+                                ]
+                              }
+                            },
+                            "input": {
                               "join": {
                                 "left": {
                                   "join": {
@@ -104,128 +113,234 @@
                                         "left": {
                                           "join": {
                                             "left": {
-                                              "read": {
-                                                "common": {
-                                                  "direct": {}
-                                                },
-                                                "baseSchema": {
-                                                  "names": [
-                                                    "l_orderkey",
-                                                    "l_partkey",
-                                                    "l_suppkey",
-                                                    "l_linenumber",
-                                                    "l_quantity",
-                                                    "l_extendedprice",
-                                                    "l_discount",
-                                                    "l_tax",
-                                                    "l_returnflag",
-                                                    "l_linestatus",
-                                                    "l_shipdate",
-                                                    "l_commitdate",
-                                                    "l_receiptdate",
-                                                    "l_shipinstruct",
-                                                    "l_shipmode",
-                                                    "l_comment"
-                                                  ],
-                                                  "struct": {
-                                                    "types": [
-                                                      {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "i64": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "date": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "date": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "date": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
+                                              "join": {
+                                                "left": {
+                                                  "read": {
+                                                    "common": {
+                                                      "direct": {}
+                                                    },
+                                                    "baseSchema": {
+                                                      "names": [
+                                                        "l_orderkey",
+                                                        "l_partkey",
+                                                        "l_suppkey",
+                                                        "l_linenumber",
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_tax",
+                                                        "l_returnflag",
+                                                        "l_linestatus",
+                                                        "l_shipdate",
+                                                        "l_commitdate",
+                                                        "l_receiptdate",
+                                                        "l_shipinstruct",
+                                                        "l_shipmode",
+                                                        "l_comment"
+                                                      ],
+                                                      "struct": {
+                                                        "types": [
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i64": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "date": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "date": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "date": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
                                                       }
-                                                    ],
-                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                    },
+                                                    "namedTable": {
+                                                      "names": [
+                                                        "lineitem"
+                                                      ]
+                                                    }
                                                   }
                                                 },
-                                                "namedTable": {
-                                                  "names": [
-                                                    "lineitem"
-                                                  ]
-                                                }
+                                                "right": {
+                                                  "read": {
+                                                    "common": {
+                                                      "direct": {}
+                                                    },
+                                                    "baseSchema": {
+                                                      "names": [
+                                                        "s_suppkey",
+                                                        "s_name",
+                                                        "s_address",
+                                                        "s_nationkey",
+                                                        "s_phone",
+                                                        "s_acctbal",
+                                                        "s_comment"
+                                                      ],
+                                                      "struct": {
+                                                        "types": [
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "i32": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          {
+                                                            "string": {
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          }
+                                                        ],
+                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                      }
+                                                    },
+                                                    "namedTable": {
+                                                      "names": [
+                                                        "supplier"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "expression": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 1,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 16
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 2
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "JOIN_TYPE_INNER"
                                               }
                                             },
                                             "right": {
@@ -235,13 +350,11 @@
                                                 },
                                                 "baseSchema": {
                                                   "names": [
-                                                    "s_suppkey",
-                                                    "s_name",
-                                                    "s_address",
-                                                    "s_nationkey",
-                                                    "s_phone",
-                                                    "s_acctbal",
-                                                    "s_comment"
+                                                    "ps_partkey",
+                                                    "ps_suppkey",
+                                                    "ps_availqty",
+                                                    "ps_supplycost",
+                                                    "ps_comment"
                                                   ],
                                                   "struct": {
                                                     "types": [
@@ -251,22 +364,12 @@
                                                         }
                                                       },
                                                       {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
-                                                        "string": {
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      {
                                                         "i32": {
                                                           "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
                                                       {
-                                                        "string": {
+                                                        "i32": {
                                                           "nullability": "NULLABILITY_REQUIRED"
                                                         }
                                                       },
@@ -288,14 +391,14 @@
                                                 },
                                                 "namedTable": {
                                                   "names": [
-                                                    "supplier"
+                                                    "partsupp"
                                                   ]
                                                 }
                                               }
                                             },
                                             "expression": {
                                               "scalarFunction": {
-                                                "functionReference": 1,
+                                                "functionReference": 2,
                                                 "outputType": {
                                                   "bool": {
                                                     "nullability": "NULLABILITY_NULLABLE"
@@ -304,25 +407,77 @@
                                                 "arguments": [
                                                   {
                                                     "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 16
+                                                      "scalarFunction": {
+                                                        "functionReference": 1,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
                                                           }
                                                         },
-                                                        "rootReference": {}
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 24
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 2
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
                                                       }
                                                     }
                                                   },
                                                   {
                                                     "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 2
+                                                      "scalarFunction": {
+                                                        "functionReference": 1,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
                                                           }
                                                         },
-                                                        "rootReference": {}
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 23
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 1
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
                                                       }
                                                     }
                                                   }
@@ -339,11 +494,15 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "ps_partkey",
-                                                "ps_suppkey",
-                                                "ps_availqty",
-                                                "ps_supplycost",
-                                                "ps_comment"
+                                                "p_partkey",
+                                                "p_name",
+                                                "p_mfgr",
+                                                "p_brand",
+                                                "p_type",
+                                                "p_size",
+                                                "p_container",
+                                                "p_retailprice",
+                                                "p_comment"
                                               ],
                                               "struct": {
                                                 "types": [
@@ -353,12 +512,32 @@
                                                     }
                                                   },
                                                   {
-                                                    "i32": {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
                                                       "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
@@ -380,14 +559,14 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "partsupp"
+                                                "part"
                                               ]
                                             }
                                           }
                                         },
                                         "expression": {
                                           "scalarFunction": {
-                                            "functionReference": 2,
+                                            "functionReference": 1,
                                             "outputType": {
                                               "bool": {
                                                 "nullability": "NULLABILITY_NULLABLE"
@@ -396,77 +575,25 @@
                                             "arguments": [
                                               {
                                                 "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 1,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 28
                                                       }
                                                     },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 24
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 2
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
+                                                    "rootReference": {}
                                                   }
                                                 }
                                               },
                                               {
                                                 "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 1,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 1
                                                       }
                                                     },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 23
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 1
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
+                                                    "rootReference": {}
                                                   }
                                                 }
                                               }
@@ -483,40 +610,20 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "p_partkey",
-                                            "p_name",
-                                            "p_mfgr",
-                                            "p_brand",
-                                            "p_type",
-                                            "p_size",
-                                            "p_container",
-                                            "p_retailprice",
-                                            "p_comment"
+                                            "o_orderkey",
+                                            "o_custkey",
+                                            "o_orderstatus",
+                                            "o_totalprice",
+                                            "o_orderdate",
+                                            "o_orderpriority",
+                                            "o_clerk",
+                                            "o_shippriority",
+                                            "o_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
                                                 "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -538,6 +645,26 @@
                                                 }
                                               },
                                               {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
                                                 "string": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
@@ -548,7 +675,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "part"
+                                            "orders"
                                           ]
                                         }
                                       }
@@ -567,7 +694,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 28
+                                                    "field": 37
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -578,9 +705,7 @@
                                             "value": {
                                               "selection": {
                                                 "directReference": {
-                                                  "structField": {
-                                                    "field": 1
-                                                  }
+                                                  "structField": {}
                                                 },
                                                 "rootReference": {}
                                               }
@@ -599,47 +724,15 @@
                                     },
                                     "baseSchema": {
                                       "names": [
-                                        "o_orderkey",
-                                        "o_custkey",
-                                        "o_orderstatus",
-                                        "o_totalprice",
-                                        "o_orderdate",
-                                        "o_orderpriority",
-                                        "o_clerk",
-                                        "o_shippriority",
-                                        "o_comment"
+                                        "n_nationkey",
+                                        "n_name",
+                                        "n_regionkey",
+                                        "n_comment"
                                       ],
                                       "struct": {
                                         "types": [
                                           {
                                             "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
                                               "nullability": "NULLABILITY_REQUIRED"
                                             }
                                           },
@@ -664,7 +757,7 @@
                                     },
                                     "namedTable": {
                                       "names": [
-                                        "orders"
+                                        "nation"
                                       ]
                                     }
                                   }
@@ -683,7 +776,7 @@
                                           "selection": {
                                             "directReference": {
                                               "structField": {
-                                                "field": 37
+                                                "field": 19
                                               }
                                             },
                                             "rootReference": {}
@@ -694,7 +787,9 @@
                                         "value": {
                                           "selection": {
                                             "directReference": {
-                                              "structField": {}
+                                              "structField": {
+                                                "field": 46
+                                              }
                                             },
                                             "rootReference": {}
                                           }
@@ -706,375 +801,323 @@
                                 "type": "JOIN_TYPE_INNER"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "n_nationkey",
-                                    "n_name",
-                                    "n_regionkey",
-                                    "n_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "nation"
-                                  ]
-                                }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 19
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 46
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "type": "JOIN_TYPE_INNER"
-                          }
-                        },
-                        "expressions": [
-                          {
-                            "scalarFunction": {
-                              "functionReference": 3,
-                              "outputType": {
-                                "decimal": {
-                                  "scale": 2,
-                                  "precision": 15,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "value": {
-                                    "scalarFunction": {
-                                      "functionReference": 4,
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 5
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "scalarFunction": {
-                                              "functionReference": 3,
-                                              "outputType": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "arguments": [
-                                                {
-                                                  "value": {
-                                                    "cast": {
-                                                      "type": {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "input": {
-                                                        "literal": {
-                                                          "i8": 1
-                                                        }
-                                                      },
-                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                    }
-                                                  }
-                                                },
-                                                {
-                                                  "value": {
-                                                    "selection": {
-                                                      "directReference": {
-                                                        "structField": {
-                                                          "field": 6
-                                                        }
-                                                      },
-                                                      "rootReference": {}
-                                                    }
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "value": {
-                                    "scalarFunction": {
-                                      "functionReference": 4,
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "cast": {
-                                              "type": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "input": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 26
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              },
-                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 4
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  }
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "cast": {
-                              "type": {
-                                "string": {
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                }
-                              },
-                              "input": {
+                            "expressions": [
+                              {
                                 "scalarFunction": {
-                                  "functionReference": 5,
+                                  "functionReference": 3,
                                   "outputType": {
-                                    "i32": {
+                                    "decimal": {
+                                      "scale": 2,
+                                      "precision": 15,
                                       "nullability": "NULLABILITY_NULLABLE"
                                     }
                                   },
                                   "arguments": [
                                     {
-                                      "enum": "YEAR"
+                                      "value": {
+                                        "scalarFunction": {
+                                          "functionReference": 4,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 5
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "scalarFunction": {
+                                                  "functionReference": 3,
+                                                  "outputType": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "arguments": [
+                                                    {
+                                                      "value": {
+                                                        "cast": {
+                                                          "type": {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "input": {
+                                                            "literal": {
+                                                              "i8": 1
+                                                            }
+                                                          },
+                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "value": {
+                                                        "selection": {
+                                                          "directReference": {
+                                                            "structField": {
+                                                              "field": 6
+                                                            }
+                                                          },
+                                                          "rootReference": {}
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
                                     },
                                     {
                                       "value": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 41
+                                        "scalarFunction": {
+                                          "functionReference": 4,
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
-                                          "rootReference": {}
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "cast": {
+                                                  "type": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "input": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 26
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  },
+                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 4
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            }
+                                          ]
                                         }
                                       }
                                     }
                                   ]
                                 }
                               },
-                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 47
+                              {
+                                "cast": {
+                                  "type": {
+                                    "string": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "input": {
+                                    "scalarFunction": {
+                                      "functionReference": 5,
+                                      "outputType": {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "enum": "YEAR"
+                                        },
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 41
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
                                 }
                               },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 29
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 47
+                                    }
+                                  },
+                                  "rootReference": {}
                                 }
                               },
-                              "rootReference": {}
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 6,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 29
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            ]
                           }
                         },
-                        "arguments": [
-                          {
-                            "value": {
-                              "selection": {
-                                "directReference": {
-                                  "structField": {
-                                    "field": 29
-                                  }
-                                },
-                                "rootReference": {}
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 6,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
                               }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "selection": {
+                                    "directReference": {
+                                      "structField": {
+                                        "field": 29
+                                      }
+                                    },
+                                    "rootReference": {}
+                                  }
+                                }
+                              },
+                              {
+                                "value": {
+                                  "literal": {
+                                    "string": "%GREEN%"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "groupings": [
+                      {
+                        "groupingExpressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
                             }
                           },
                           {
-                            "value": {
-                              "literal": {
-                                "string": "%GREEN%"
-                              }
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
                             }
                           }
                         ]
                       }
-                    }
-                  }
-                },
-                "groupings": [
-                  {
-                    "groupingExpressions": [
+                    ],
+                    "measures": [
                       {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 2
+                        "measure": {
+                          "functionReference": 7,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
                             }
                           },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 1
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
                             }
-                          },
-                          "rootReference": {}
+                          ]
                         }
                       }
                     ]
                   }
-                ],
-                "measures": [
+                },
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 7,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
-                              },
-                              "rootReference": {}
-                            }
-                          }
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 2
                         }
-                      ]
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
@@ -72,129 +72,259 @@
             "input": {
               "sort": {
                 "input": {
-                  "aggregate": {
+                  "project": {
+                    "common": {
+                      "emit": {
+                        "outputMapping": [
+                          8,
+                          9,
+                          10,
+                          11,
+                          12,
+                          13,
+                          14,
+                          15
+                        ]
+                      }
+                    },
                     "input": {
-                      "filter": {
+                      "aggregate": {
                         "input": {
-                          "project": {
-                            "common": {
-                              "emit": {
-                                "outputMapping": [
-                                  37,
-                                  38,
-                                  39,
-                                  40,
-                                  41,
-                                  42,
-                                  43,
-                                  44,
-                                  45,
-                                  46,
-                                  47,
-                                  48,
-                                  49,
-                                  50,
-                                  51,
-                                  52,
-                                  53,
-                                  54,
-                                  55,
-                                  56,
-                                  57,
-                                  58,
-                                  59,
-                                  60,
-                                  61,
-                                  62,
-                                  63,
-                                  64,
-                                  65,
-                                  66,
-                                  67,
-                                  68,
-                                  69,
-                                  70,
-                                  71,
-                                  72,
-                                  73
-                                ]
-                              }
-                            },
+                          "filter": {
                             "input": {
-                              "join": {
-                                "left": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      37,
+                                      38,
+                                      39,
+                                      40,
+                                      41,
+                                      42,
+                                      43,
+                                      44,
+                                      45,
+                                      46,
+                                      47,
+                                      48,
+                                      49,
+                                      50,
+                                      51,
+                                      52,
+                                      53,
+                                      54,
+                                      55,
+                                      56,
+                                      57,
+                                      58,
+                                      59,
+                                      60,
+                                      61,
+                                      62,
+                                      63,
+                                      64,
+                                      65,
+                                      66,
+                                      67,
+                                      68,
+                                      69,
+                                      70,
+                                      71,
+                                      72,
+                                      73
+                                    ]
+                                  }
+                                },
+                                "input": {
                                   "join": {
                                     "left": {
                                       "join": {
                                         "left": {
-                                          "read": {
-                                            "common": {
-                                              "direct": {}
-                                            },
-                                            "baseSchema": {
-                                              "names": [
-                                                "c_custkey",
-                                                "c_name",
-                                                "c_address",
-                                                "c_nationkey",
-                                                "c_phone",
-                                                "c_acctbal",
-                                                "c_mktsegment",
-                                                "c_comment"
-                                              ],
-                                              "struct": {
-                                                "types": [
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
+                                          "join": {
+                                            "left": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "c_custkey",
+                                                    "c_name",
+                                                    "c_address",
+                                                    "c_nationkey",
+                                                    "c_phone",
+                                                    "c_acctbal",
+                                                    "c_mktsegment",
+                                                    "c_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
                                                   }
-                                                ],
-                                                "nullability": "NULLABILITY_REQUIRED"
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "customer"
+                                                  ]
+                                                }
                                               }
                                             },
-                                            "namedTable": {
-                                              "names": [
-                                                "customer"
-                                              ]
-                                            }
+                                            "right": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "o_orderkey",
+                                                    "o_custkey",
+                                                    "o_orderstatus",
+                                                    "o_totalprice",
+                                                    "o_orderdate",
+                                                    "o_orderpriority",
+                                                    "o_clerk",
+                                                    "o_shippriority",
+                                                    "o_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                  }
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "orders"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expression": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 9
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "JOIN_TYPE_INNER"
                                           }
                                         },
                                         "right": {
@@ -204,63 +334,111 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "o_orderkey",
-                                                "o_custkey",
-                                                "o_orderstatus",
-                                                "o_totalprice",
-                                                "o_orderdate",
-                                                "o_orderpriority",
-                                                "o_clerk",
-                                                "o_shippriority",
-                                                "o_comment"
+                                                "l_orderkey",
+                                                "l_partkey",
+                                                "l_suppkey",
+                                                "l_linenumber",
+                                                "l_quantity",
+                                                "l_extendedprice",
+                                                "l_discount",
+                                                "l_tax",
+                                                "l_returnflag",
+                                                "l_linestatus",
+                                                "l_shipdate",
+                                                "l_commitdate",
+                                                "l_receiptdate",
+                                                "l_shipinstruct",
+                                                "l_shipmode",
+                                                "l_comment"
                                               ],
                                               "struct": {
                                                 "types": [
                                                   {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "decimal": {
                                                       "scale": 2,
                                                       "precision": 15,
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "date": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                      "nullability": "NULLABILITY_NULLABLE"
                                                     }
                                                   }
                                                 ],
@@ -269,7 +447,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "orders"
+                                                "lineitem"
                                               ]
                                             }
                                           }
@@ -287,7 +465,9 @@
                                                 "value": {
                                                   "selection": {
                                                     "directReference": {
-                                                      "structField": {}
+                                                      "structField": {
+                                                        "field": 17
+                                                      }
                                                     },
                                                     "rootReference": {}
                                                   }
@@ -298,7 +478,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 9
+                                                        "field": 8
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -318,111 +498,31 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "l_orderkey",
-                                            "l_partkey",
-                                            "l_suppkey",
-                                            "l_linenumber",
-                                            "l_quantity",
-                                            "l_extendedprice",
-                                            "l_discount",
-                                            "l_tax",
-                                            "l_returnflag",
-                                            "l_linestatus",
-                                            "l_shipdate",
-                                            "l_commitdate",
-                                            "l_receiptdate",
-                                            "l_shipinstruct",
-                                            "l_shipmode",
-                                            "l_comment"
+                                            "n_nationkey",
+                                            "n_name",
+                                            "n_regionkey",
+                                            "n_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                  "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               }
                                             ],
@@ -431,7 +531,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "lineitem"
+                                            "nation"
                                           ]
                                         }
                                       }
@@ -450,7 +550,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 17
+                                                    "field": 3
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -462,7 +562,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 8
+                                                    "field": 33
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -475,91 +575,508 @@
                                     "type": "JOIN_TYPE_INNER"
                                   }
                                 },
-                                "right": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "n_nationkey",
-                                        "n_name",
-                                        "n_regionkey",
-                                        "n_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "nation"
-                                      ]
+                                "expressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
                                     }
-                                  }
-                                },
-                                "expression": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 3
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
                                         }
                                       },
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 33
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 2
                                         }
-                                      }
-                                    ]
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 3
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 7
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 8
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 9
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 10
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 11
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 12
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 13
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 14
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 15
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 16
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 17
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 18
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 19
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 20
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 21
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 22
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 23
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 24
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 25
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 26
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 27
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 28
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 29
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 30
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 31
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 32
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 33
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 34
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 35
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 36
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
                                   }
-                                },
-                                "type": "JOIN_TYPE_INNER"
+                                ]
                               }
                             },
-                            "expressions": [
+                            "condition": {
+                              "scalarFunction": {
+                                "functionReference": 2,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 2,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 12
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "1993-01-01"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 4,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 12
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "1993-04-01"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 25
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "literal": {
+                                                "string": "R"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "groupings": [
+                          {
+                            "groupingExpressions": [
                               {
                                 "selection": {
                                   "directReference": {
@@ -582,17 +1099,7 @@
                                 "selection": {
                                   "directReference": {
                                     "structField": {
-                                      "field": 2
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 3
+                                      "field": 5
                                     }
                                   },
                                   "rootReference": {}
@@ -612,7 +1119,7 @@
                                 "selection": {
                                   "directReference": {
                                     "structField": {
-                                      "field": 5
+                                      "field": 34
                                     }
                                   },
                                   "rootReference": {}
@@ -622,7 +1129,7 @@
                                 "selection": {
                                   "directReference": {
                                     "structField": {
-                                      "field": 6
+                                      "field": 2
                                     }
                                   },
                                   "rootReference": {}
@@ -637,590 +1144,181 @@
                                   },
                                   "rootReference": {}
                                 }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 8
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 9
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 10
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 11
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 12
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 13
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 14
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 15
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 16
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 17
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 18
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 19
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 20
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 21
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 22
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 23
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 24
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 25
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 26
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 27
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 28
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 29
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 30
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 31
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 32
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 33
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 34
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 35
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 36
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
                               }
                             ]
                           }
-                        },
-                        "condition": {
-                          "scalarFunction": {
-                            "functionReference": 2,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 2,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 12
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "1993-01-01"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
+                        ],
+                        "measures": [
+                          {
+                            "measure": {
+                              "functionReference": 5,
+                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 38,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 6,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
                                         }
                                       },
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 4,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 12
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 22
                                                 }
                                               },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "1993-04-01"
+                                              "rootReference": {}
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "scalarFunction": {
+                                              "functionReference": 7,
+                                              "outputType": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "cast": {
+                                                      "type": {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "input": {
+                                                        "literal": {
+                                                          "i8": 1
+                                                        }
+                                                      },
+                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 23
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
                                                   }
                                                 }
-                                              }
-                                            ]
+                                              ]
+                                            }
                                           }
                                         }
-                                      }
-                                    ]
+                                      ]
+                                    }
                                   }
                                 }
-                              },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 25
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "literal": {
-                                            "string": "R"
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    },
-                    "groupings": [
-                      {
-                        "groupingExpressions": [
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 34
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 2
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 7
-                                }
-                              },
-                              "rootReference": {}
+                              ]
                             }
                           }
                         ]
                       }
-                    ],
-                    "measures": [
+                    },
+                    "expressions": [
                       {
-                        "measure": {
-                          "functionReference": 5,
-                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 38,
-                              "nullability": "NULLABILITY_NULLABLE"
+                        "selection": {
+                          "directReference": {
+                            "structField": {}
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
                             }
                           },
-                          "arguments": [
-                            {
-                              "value": {
-                                "scalarFunction": {
-                                  "functionReference": 6,
-                                  "outputType": {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "value": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 22
-                                            }
-                                          },
-                                          "rootReference": {}
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "value": {
-                                        "scalarFunction": {
-                                          "functionReference": 7,
-                                          "outputType": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "cast": {
-                                                  "type": {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  "input": {
-                                                    "literal": {
-                                                      "i8": 1
-                                                    }
-                                                  },
-                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 23
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
                             }
-                          ]
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 3
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 4
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 5
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 6
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 7
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
@@ -47,88 +47,202 @@
             "input": {
               "filter": {
                 "input": {
-                  "aggregate": {
+                  "project": {
+                    "common": {
+                      "emit": {
+                        "outputMapping": [
+                          2,
+                          3
+                        ]
+                      }
+                    },
                     "input": {
-                      "filter": {
+                      "aggregate": {
                         "input": {
-                          "project": {
-                            "common": {
-                              "emit": {
-                                "outputMapping": [
-                                  16,
-                                  17,
-                                  18,
-                                  19,
-                                  20,
-                                  21,
-                                  22,
-                                  23,
-                                  24,
-                                  25,
-                                  26,
-                                  27,
-                                  28,
-                                  29,
-                                  30,
-                                  31
-                                ]
-                              }
-                            },
+                          "filter": {
                             "input": {
-                              "join": {
-                                "left": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      16,
+                                      17,
+                                      18,
+                                      19,
+                                      20,
+                                      21,
+                                      22,
+                                      23,
+                                      24,
+                                      25,
+                                      26,
+                                      27,
+                                      28,
+                                      29,
+                                      30,
+                                      31
+                                    ]
+                                  }
+                                },
+                                "input": {
                                   "join": {
                                     "left": {
-                                      "read": {
-                                        "common": {
-                                          "direct": {}
-                                        },
-                                        "baseSchema": {
-                                          "names": [
-                                            "ps_partkey",
-                                            "ps_suppkey",
-                                            "ps_availqty",
-                                            "ps_supplycost",
-                                            "ps_comment"
-                                          ],
-                                          "struct": {
-                                            "types": [
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
+                                      "join": {
+                                        "left": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "ps_partkey",
+                                                "ps_suppkey",
+                                                "ps_availqty",
+                                                "ps_supplycost",
+                                                "ps_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
                                               }
-                                            ],
-                                            "nullability": "NULLABILITY_REQUIRED"
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "partsupp"
+                                              ]
+                                            }
                                           }
                                         },
-                                        "namedTable": {
-                                          "names": [
-                                            "partsupp"
-                                          ]
-                                        }
+                                        "right": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "s_suppkey",
+                                                "s_name",
+                                                "s_address",
+                                                "s_nationkey",
+                                                "s_phone",
+                                                "s_acctbal",
+                                                "s_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                              }
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "supplier"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "expression": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 1
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 5
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "JOIN_TYPE_INNER"
                                       }
                                     },
                                     "right": {
@@ -138,13 +252,10 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "s_suppkey",
-                                            "s_name",
-                                            "s_address",
-                                            "s_nationkey",
-                                            "s_phone",
-                                            "s_acctbal",
-                                            "s_comment"
+                                            "n_nationkey",
+                                            "n_name",
+                                            "n_regionkey",
+                                            "n_comment"
                                           ],
                                           "struct": {
                                             "types": [
@@ -159,24 +270,7 @@
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
                                                 "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -191,7 +285,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "supplier"
+                                            "nation"
                                           ]
                                         }
                                       }
@@ -210,7 +304,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 1
+                                                    "field": 12
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -222,7 +316,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 5
+                                                    "field": 8
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -235,91 +329,204 @@
                                     "type": "JOIN_TYPE_INNER"
                                   }
                                 },
-                                "right": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "n_nationkey",
-                                        "n_name",
-                                        "n_regionkey",
-                                        "n_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "nation"
-                                      ]
+                                "expressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
                                     }
-                                  }
-                                },
-                                "expression": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 12
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
                                         }
                                       },
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 8
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 2
                                         }
-                                      }
-                                    ]
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 3
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 7
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 8
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 9
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 10
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 11
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 12
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 13
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 14
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 15
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
                                   }
-                                },
-                                "type": "JOIN_TYPE_INNER"
+                                ]
                               }
                             },
-                            "expressions": [
+                            "condition": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 13
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "literal": {
+                                        "string": "GERMANY"
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "groupings": [
+                          {
+                            "groupingExpressions": [
                               {
                                 "selection": {
                                   "directReference": {
@@ -327,273 +534,98 @@
                                   },
                                   "rootReference": {}
                                 }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 1
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 2
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 3
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 4
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 5
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 6
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 7
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 8
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 9
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 10
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 11
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 12
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 13
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 14
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 15
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
                               }
                             ]
                           }
-                        },
-                        "condition": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 13
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "literal": {
-                                    "string": "GERMANY"
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    },
-                    "groupings": [
-                      {
-                        "groupingExpressions": [
+                        ],
+                        "measures": [
                           {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
+                            "measure": {
+                              "functionReference": 2,
+                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 38,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
                               },
-                              "rootReference": {}
-                            }
-                          }
-                        ]
-                      }
-                    ],
-                    "measures": [
-                      {
-                        "measure": {
-                          "functionReference": 2,
-                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 38,
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          "arguments": [
-                            {
-                              "value": {
-                                "scalarFunction": {
-                                  "functionReference": 3,
-                                  "outputType": {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "value": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 3
-                                            }
-                                          },
-                                          "rootReference": {}
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 3,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
                                         }
-                                      }
-                                    },
-                                    {
-                                      "value": {
-                                        "cast": {
-                                          "type": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "input": {
+                                      },
+                                      "arguments": [
+                                        {
+                                          "value": {
                                             "selection": {
                                               "directReference": {
                                                 "structField": {
-                                                  "field": 2
+                                                  "field": 3
                                                 }
                                               },
                                               "rootReference": {}
                                             }
-                                          },
-                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "cast": {
+                                              "type": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "input": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 2
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              },
+                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            }
+                                          }
                                         }
-                                      }
+                                      ]
                                     }
-                                  ]
+                                  }
                                 }
-                              }
+                              ]
                             }
-                          ]
+                          }
+                        ]
+                      }
+                    },
+                    "expressions": [
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {}
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     ]
@@ -637,88 +669,201 @@
                                   "subquery": {
                                     "scalar": {
                                       "input": {
-                                        "aggregate": {
+                                        "project": {
+                                          "common": {
+                                            "emit": {
+                                              "outputMapping": [
+                                                1
+                                              ]
+                                            }
+                                          },
                                           "input": {
-                                            "filter": {
+                                            "aggregate": {
                                               "input": {
-                                                "project": {
-                                                  "common": {
-                                                    "emit": {
-                                                      "outputMapping": [
-                                                        16,
-                                                        17,
-                                                        18,
-                                                        19,
-                                                        20,
-                                                        21,
-                                                        22,
-                                                        23,
-                                                        24,
-                                                        25,
-                                                        26,
-                                                        27,
-                                                        28,
-                                                        29,
-                                                        30,
-                                                        31
-                                                      ]
-                                                    }
-                                                  },
+                                                "filter": {
                                                   "input": {
-                                                    "join": {
-                                                      "left": {
+                                                    "project": {
+                                                      "common": {
+                                                        "emit": {
+                                                          "outputMapping": [
+                                                            16,
+                                                            17,
+                                                            18,
+                                                            19,
+                                                            20,
+                                                            21,
+                                                            22,
+                                                            23,
+                                                            24,
+                                                            25,
+                                                            26,
+                                                            27,
+                                                            28,
+                                                            29,
+                                                            30,
+                                                            31
+                                                          ]
+                                                        }
+                                                      },
+                                                      "input": {
                                                         "join": {
                                                           "left": {
-                                                            "read": {
-                                                              "common": {
-                                                                "direct": {}
-                                                              },
-                                                              "baseSchema": {
-                                                                "names": [
-                                                                  "ps_partkey",
-                                                                  "ps_suppkey",
-                                                                  "ps_availqty",
-                                                                  "ps_supplycost",
-                                                                  "ps_comment"
-                                                                ],
-                                                                "struct": {
-                                                                  "types": [
-                                                                    {
-                                                                      "i32": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "i32": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "i32": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
+                                                            "join": {
+                                                              "left": {
+                                                                "read": {
+                                                                  "common": {
+                                                                    "direct": {}
+                                                                  },
+                                                                  "baseSchema": {
+                                                                    "names": [
+                                                                      "ps_partkey",
+                                                                      "ps_suppkey",
+                                                                      "ps_availqty",
+                                                                      "ps_supplycost",
+                                                                      "ps_comment"
+                                                                    ],
+                                                                    "struct": {
+                                                                      "types": [
+                                                                        {
+                                                                          "i32": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "i32": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "i32": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        }
+                                                                      ],
+                                                                      "nullability": "NULLABILITY_REQUIRED"
                                                                     }
-                                                                  ],
-                                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                                  },
+                                                                  "namedTable": {
+                                                                    "names": [
+                                                                      "partsupp"
+                                                                    ]
+                                                                  }
                                                                 }
                                                               },
-                                                              "namedTable": {
-                                                                "names": [
-                                                                  "partsupp"
-                                                                ]
-                                                              }
+                                                              "right": {
+                                                                "read": {
+                                                                  "common": {
+                                                                    "direct": {}
+                                                                  },
+                                                                  "baseSchema": {
+                                                                    "names": [
+                                                                      "s_suppkey",
+                                                                      "s_name",
+                                                                      "s_address",
+                                                                      "s_nationkey",
+                                                                      "s_phone",
+                                                                      "s_acctbal",
+                                                                      "s_comment"
+                                                                    ],
+                                                                    "struct": {
+                                                                      "types": [
+                                                                        {
+                                                                          "i32": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "i32": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_REQUIRED"
+                                                                          }
+                                                                        }
+                                                                      ],
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  "namedTable": {
+                                                                    "names": [
+                                                                      "supplier"
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              },
+                                                              "expression": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 1,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 1
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 5
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "JOIN_TYPE_INNER"
                                                             }
                                                           },
                                                           "right": {
@@ -728,13 +873,10 @@
                                                               },
                                                               "baseSchema": {
                                                                 "names": [
-                                                                  "s_suppkey",
-                                                                  "s_name",
-                                                                  "s_address",
-                                                                  "s_nationkey",
-                                                                  "s_phone",
-                                                                  "s_acctbal",
-                                                                  "s_comment"
+                                                                  "n_nationkey",
+                                                                  "n_name",
+                                                                  "n_regionkey",
+                                                                  "n_comment"
                                                                 ],
                                                                 "struct": {
                                                                   "types": [
@@ -749,24 +891,7 @@
                                                                       }
                                                                     },
                                                                     {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
                                                                       "i32": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_REQUIRED"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
                                                                         "nullability": "NULLABILITY_REQUIRED"
                                                                       }
                                                                     },
@@ -781,7 +906,7 @@
                                                               },
                                                               "namedTable": {
                                                                 "names": [
-                                                                  "supplier"
+                                                                  "nation"
                                                                 ]
                                                               }
                                                             }
@@ -800,7 +925,7 @@
                                                                     "selection": {
                                                                       "directReference": {
                                                                         "structField": {
-                                                                          "field": 1
+                                                                          "field": 12
                                                                         }
                                                                       },
                                                                       "rootReference": {}
@@ -812,7 +937,7 @@
                                                                     "selection": {
                                                                       "directReference": {
                                                                         "structField": {
-                                                                          "field": 5
+                                                                          "field": 8
                                                                         }
                                                                       },
                                                                       "rootReference": {}
@@ -825,354 +950,282 @@
                                                           "type": "JOIN_TYPE_INNER"
                                                         }
                                                       },
-                                                      "right": {
-                                                        "read": {
-                                                          "common": {
-                                                            "direct": {}
-                                                          },
-                                                          "baseSchema": {
-                                                            "names": [
-                                                              "n_nationkey",
-                                                              "n_name",
-                                                              "n_regionkey",
-                                                              "n_comment"
-                                                            ],
-                                                            "struct": {
-                                                              "types": [
-                                                                {
-                                                                  "i32": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "i32": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_REQUIRED"
-                                                                  }
-                                                                }
-                                                              ],
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          },
-                                                          "namedTable": {
-                                                            "names": [
-                                                              "nation"
-                                                            ]
+                                                      "expressions": [
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {}
+                                                            },
+                                                            "rootReference": {}
                                                           }
-                                                        }
-                                                      },
-                                                      "expression": {
-                                                        "scalarFunction": {
-                                                          "functionReference": 1,
-                                                          "outputType": {
-                                                            "bool": {
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "arguments": [
-                                                            {
-                                                              "value": {
-                                                                "selection": {
-                                                                  "directReference": {
-                                                                    "structField": {
-                                                                      "field": 12
-                                                                    }
-                                                                  },
-                                                                  "rootReference": {}
-                                                                }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 1
                                                               }
                                                             },
-                                                            {
-                                                              "value": {
-                                                                "selection": {
-                                                                  "directReference": {
-                                                                    "structField": {
-                                                                      "field": 8
-                                                                    }
-                                                                  },
-                                                                  "rootReference": {}
-                                                                }
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 2
                                                               }
-                                                            }
-                                                          ]
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 3
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 4
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 5
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 6
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 7
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 8
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 9
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 10
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 11
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 12
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 13
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 14
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 15
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "condition": {
+                                                    "scalarFunction": {
+                                                      "functionReference": 1,
+                                                      "outputType": {
+                                                        "bool": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
                                                       },
-                                                      "type": "JOIN_TYPE_INNER"
+                                                      "arguments": [
+                                                        {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 13
+                                                                }
+                                                              },
+                                                              "rootReference": {}
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "value": {
+                                                            "literal": {
+                                                              "string": "GERMANY"
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
                                                     }
-                                                  },
-                                                  "expressions": [
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {}
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 1
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 2
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 3
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 4
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 5
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 6
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 7
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 8
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 9
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 10
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 11
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 12
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 13
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 14
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 15
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  ]
+                                                  }
                                                 }
                                               },
-                                              "condition": {
-                                                "scalarFunction": {
-                                                  "functionReference": 1,
-                                                  "outputType": {
-                                                    "bool": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  "arguments": [
-                                                    {
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 13
-                                                            }
-                                                          },
-                                                          "rootReference": {}
-                                                        }
+                                              "groupings": [
+                                                {}
+                                              ],
+                                              "measures": [
+                                                {
+                                                  "measure": {
+                                                    "functionReference": 2,
+                                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                    "outputType": {
+                                                      "decimal": {
+                                                        "scale": 2,
+                                                        "precision": 38,
+                                                        "nullability": "NULLABILITY_NULLABLE"
                                                       }
                                                     },
-                                                    {
-                                                      "value": {
-                                                        "literal": {
-                                                          "string": "GERMANY"
-                                                        }
-                                                      }
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            }
-                                          },
-                                          "groupings": [
-                                            {}
-                                          ],
-                                          "measures": [
-                                            {
-                                              "measure": {
-                                                "functionReference": 2,
-                                                "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                "outputType": {
-                                                  "decimal": {
-                                                    "scale": 2,
-                                                    "precision": 38,
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "scalarFunction": {
-                                                        "functionReference": 3,
-                                                        "outputType": {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        "arguments": [
-                                                          {
-                                                            "value": {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 3
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "scalarFunction": {
+                                                            "functionReference": 3,
+                                                            "outputType": {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
                                                               }
-                                                            }
-                                                          },
-                                                          {
-                                                            "value": {
-                                                              "cast": {
-                                                                "type": {
-                                                                  "decimal": {
-                                                                    "scale": 2,
-                                                                    "precision": 15,
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                "input": {
+                                                            },
+                                                            "arguments": [
+                                                              {
+                                                                "value": {
                                                                   "selection": {
                                                                     "directReference": {
                                                                       "structField": {
-                                                                        "field": 2
+                                                                        "field": 3
                                                                       }
                                                                     },
                                                                     "rootReference": {}
                                                                   }
-                                                                },
-                                                                "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                }
+                                                              },
+                                                              {
+                                                                "value": {
+                                                                  "cast": {
+                                                                    "type": {
+                                                                      "decimal": {
+                                                                        "scale": 2,
+                                                                        "precision": 15,
+                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                      }
+                                                                    },
+                                                                    "input": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 2
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    },
+                                                                    "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                  }
+                                                                }
                                                               }
-                                                            }
+                                                            ]
                                                           }
-                                                        ]
+                                                        }
                                                       }
-                                                    }
+                                                    ]
                                                   }
-                                                ]
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "expressions": [
+                                            {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {}
+                                                },
+                                                "rootReference": {}
                                               }
                                             }
                                           ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
@@ -56,512 +56,775 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      3,
+                      4,
+                      5
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "project": {
-                        "common": {
-                          "emit": {
-                            "outputMapping": [
-                              25,
-                              26,
-                              27,
-                              28,
-                              29,
-                              30,
-                              31,
-                              32,
-                              33,
-                              34,
-                              35,
-                              36,
-                              37,
-                              38,
-                              39,
-                              40,
-                              41,
-                              42,
-                              43,
-                              44,
-                              45,
-                              46,
-                              47,
-                              48,
-                              49
-                            ]
-                          }
-                        },
+                      "filter": {
                         "input": {
-                          "join": {
-                            "left": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "o_orderkey",
-                                    "o_custkey",
-                                    "o_orderstatus",
-                                    "o_totalprice",
-                                    "o_orderdate",
-                                    "o_orderpriority",
-                                    "o_clerk",
-                                    "o_shippriority",
-                                    "o_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "orders"
-                                  ]
-                                }
-                              }
-                            },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "l_orderkey",
-                                    "l_partkey",
-                                    "l_suppkey",
-                                    "l_linenumber",
-                                    "l_quantity",
-                                    "l_extendedprice",
-                                    "l_discount",
-                                    "l_tax",
-                                    "l_returnflag",
-                                    "l_linestatus",
-                                    "l_shipdate",
-                                    "l_commitdate",
-                                    "l_receiptdate",
-                                    "l_shipinstruct",
-                                    "l_shipmode",
-                                    "l_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "lineitem"
-                                  ]
-                                }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {}
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 9
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  }
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  25,
+                                  26,
+                                  27,
+                                  28,
+                                  29,
+                                  30,
+                                  31,
+                                  32,
+                                  33,
+                                  34,
+                                  35,
+                                  36,
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42,
+                                  43,
+                                  44,
+                                  45,
+                                  46,
+                                  47,
+                                  48,
+                                  49
                                 ]
                               }
                             },
-                            "type": "JOIN_TYPE_INNER"
+                            "input": {
+                              "join": {
+                                "left": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "o_orderkey",
+                                        "o_custkey",
+                                        "o_orderstatus",
+                                        "o_totalprice",
+                                        "o_orderdate",
+                                        "o_orderpriority",
+                                        "o_clerk",
+                                        "o_shippriority",
+                                        "o_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "orders"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "right": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "l_orderkey",
+                                        "l_partkey",
+                                        "l_suppkey",
+                                        "l_linenumber",
+                                        "l_quantity",
+                                        "l_extendedprice",
+                                        "l_discount",
+                                        "l_tax",
+                                        "l_returnflag",
+                                        "l_linestatus",
+                                        "l_shipdate",
+                                        "l_commitdate",
+                                        "l_receiptdate",
+                                        "l_shipinstruct",
+                                        "l_shipmode",
+                                        "l_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "lineitem"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "expression": {
+                                  "scalarFunction": {
+                                    "functionReference": 1,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {}
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 9
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "JOIN_TYPE_INNER"
+                              }
+                            },
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            ]
                           }
                         },
-                        "expressions": [
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 2,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 2,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 2,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "singularOrList": {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 23
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            },
+                                                            "options": [
+                                                              {
+                                                                "literal": {
+                                                                  "string": "MAIL"
+                                                                }
+                                                              },
+                                                              {
+                                                                "literal": {
+                                                                  "string": "SHIP"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "scalarFunction": {
+                                                            "functionReference": 3,
+                                                            "outputType": {
+                                                              "bool": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            "arguments": [
+                                                              {
+                                                                "value": {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 20
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                }
+                                                              },
+                                                              {
+                                                                "value": {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 21
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 3,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 19
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 20
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 4,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 21
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "literal": {
+                                                    "string": "1994-01-01"
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
                                 }
                               },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 2
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 3,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 21
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "literal": {
+                                            "string": "1995-01-01"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
                                 }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 3
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 6
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 7
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 8
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 9
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 10
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 11
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 13
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 14
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 15
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 16
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 17
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 18
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 19
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 20
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 21
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 22
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "groupings": [
+                      {
+                        "groupingExpressions": [
                           {
                             "selection": {
                               "directReference": {
@@ -571,465 +834,245 @@
                               },
                               "rootReference": {}
                             }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 24
-                                }
-                              },
-                              "rootReference": {}
-                            }
                           }
                         ]
                       }
-                    },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 2,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 2,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 2,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 2,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "singularOrList": {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 23
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        },
-                                                        "options": [
-                                                          {
-                                                            "literal": {
-                                                              "string": "MAIL"
-                                                            }
-                                                          },
-                                                          {
-                                                            "literal": {
-                                                              "string": "SHIP"
-                                                            }
-                                                          }
-                                                        ]
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "scalarFunction": {
-                                                        "functionReference": 3,
-                                                        "outputType": {
-                                                          "bool": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        "arguments": [
-                                                          {
-                                                            "value": {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 20
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            }
-                                                          },
-                                                          {
-                                                            "value": {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 21
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            }
-                                                          }
-                                                        ]
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 3,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 19
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 20
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 4,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 21
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "literal": {
-                                                "string": "1994-01-01"
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 3,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 21
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "literal": {
-                                        "string": "1995-01-01"
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  }
-                },
-                "groupings": [
-                  {
-                    "groupingExpressions": [
+                    ],
+                    "measures": [
                       {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 23
+                        "measure": {
+                          "functionReference": 5,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
                             }
                           },
-                          "rootReference": {}
+                          "arguments": [
+                            {
+                              "value": {
+                                "ifThen": {
+                                  "ifs": [
+                                    {
+                                      "if": {
+                                        "scalarFunction": {
+                                          "functionReference": 1,
+                                          "outputType": {
+                                            "bool": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 5
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "literal": {
+                                                  "string": "1-URGENT"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "then": {
+                                        "literal": {
+                                          "i8": 1
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "if": {
+                                        "scalarFunction": {
+                                          "functionReference": 1,
+                                          "outputType": {
+                                            "bool": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 5
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "literal": {
+                                                  "string": "2-HIGH"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "then": {
+                                        "literal": {
+                                          "i8": 1
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "else": {
+                                    "literal": {
+                                      "i8": 0
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 5,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "ifThen": {
+                                  "ifs": [
+                                    {
+                                      "if": {
+                                        "scalarFunction": {
+                                          "functionReference": 1,
+                                          "outputType": {
+                                            "bool": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 5
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "literal": {
+                                                  "string": "1-URGENT"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "then": {
+                                        "literal": {
+                                          "i8": 0
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "if": {
+                                        "scalarFunction": {
+                                          "functionReference": 1,
+                                          "outputType": {
+                                            "bool": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "selection": {
+                                                  "directReference": {
+                                                    "structField": {
+                                                      "field": 5
+                                                    }
+                                                  },
+                                                  "rootReference": {}
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "value": {
+                                                "literal": {
+                                                  "string": "2-HIGH"
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "then": {
+                                        "literal": {
+                                          "i8": 0
+                                        }
+                                      }
+                                    }
+                                  ],
+                                  "else": {
+                                    "literal": {
+                                      "i8": 1
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     ]
                   }
-                ],
-                "measures": [
+                },
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 5,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "ifThen": {
-                              "ifs": [
-                                {
-                                  "if": {
-                                    "scalarFunction": {
-                                      "functionReference": 1,
-                                      "outputType": {
-                                        "bool": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 5
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "literal": {
-                                              "string": "1-URGENT"
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "then": {
-                                    "literal": {
-                                      "i8": 1
-                                    }
-                                  }
-                                },
-                                {
-                                  "if": {
-                                    "scalarFunction": {
-                                      "functionReference": 1,
-                                      "outputType": {
-                                        "bool": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 5
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "literal": {
-                                              "string": "2-HIGH"
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "then": {
-                                    "literal": {
-                                      "i8": 1
-                                    }
-                                  }
-                                }
-                              ],
-                              "else": {
-                                "literal": {
-                                  "i8": 0
-                                }
-                              }
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 5,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "ifThen": {
-                              "ifs": [
-                                {
-                                  "if": {
-                                    "scalarFunction": {
-                                      "functionReference": 1,
-                                      "outputType": {
-                                        "bool": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 5
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "literal": {
-                                              "string": "1-URGENT"
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "then": {
-                                    "literal": {
-                                      "i8": 0
-                                    }
-                                  }
-                                },
-                                {
-                                  "if": {
-                                    "scalarFunction": {
-                                      "functionReference": 1,
-                                      "outputType": {
-                                        "bool": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {
-                                                  "field": 5
-                                                }
-                                              },
-                                              "rootReference": {}
-                                            }
-                                          }
-                                        },
-                                        {
-                                          "value": {
-                                            "literal": {
-                                              "string": "2-HIGH"
-                                            }
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "then": {
-                                    "literal": {
-                                      "i8": 0
-                                    }
-                                  }
-                                }
-                              ],
-                              "else": {
-                                "literal": {
-                                  "i8": 1
-                                }
-                              }
-                            }
-                          }
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 2
                         }
-                      ]
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
@@ -60,7 +60,15 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      2,
+                      3
+                    ]
+                  }
+                },
                 "input": {
                   "aggregate": {
                     "input": {
@@ -68,225 +76,191 @@
                         "common": {
                           "emit": {
                             "outputMapping": [
-                              17,
-                              18,
-                              19,
-                              20,
-                              21,
-                              22,
-                              23,
-                              24,
-                              25,
-                              26,
-                              27,
-                              28,
-                              29,
-                              30,
-                              31,
-                              32,
-                              33
+                              2,
+                              3
                             ]
                           }
                         },
                         "input": {
-                          "join": {
-                            "left": {
-                              "read": {
+                          "aggregate": {
+                            "input": {
+                              "project": {
                                 "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "c_custkey",
-                                    "c_name",
-                                    "c_address",
-                                    "c_nationkey",
-                                    "c_phone",
-                                    "c_acctbal",
-                                    "c_mktsegment",
-                                    "c_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
+                                  "emit": {
+                                    "outputMapping": [
+                                      17,
+                                      18,
+                                      19,
+                                      20,
+                                      21,
+                                      22,
+                                      23,
+                                      24,
+                                      25,
+                                      26,
+                                      27,
+                                      28,
+                                      29,
+                                      30,
+                                      31,
+                                      32,
+                                      33
+                                    ]
                                   }
                                 },
-                                "namedTable": {
-                                  "names": [
-                                    "customer"
-                                  ]
-                                }
-                              }
-                            },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "o_orderkey",
-                                    "o_custkey",
-                                    "o_orderstatus",
-                                    "o_totalprice",
-                                    "o_orderdate",
-                                    "o_orderpriority",
-                                    "o_clerk",
-                                    "o_shippriority",
-                                    "o_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "orders"
-                                  ]
-                                }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 2,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
+                                "input": {
+                                  "join": {
+                                    "left": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "c_custkey",
+                                            "c_name",
+                                            "c_address",
+                                            "c_nationkey",
+                                            "c_phone",
+                                            "c_acctbal",
+                                            "c_mktsegment",
+                                            "c_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
                                           }
                                         },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {}
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 9
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          }
-                                        ]
+                                        "namedTable": {
+                                          "names": [
+                                            "customer"
+                                          ]
+                                        }
                                       }
-                                    }
-                                  },
-                                  {
-                                    "value": {
+                                    },
+                                    "right": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "o_orderkey",
+                                            "o_custkey",
+                                            "o_orderstatus",
+                                            "o_totalprice",
+                                            "o_orderdate",
+                                            "o_orderpriority",
+                                            "o_clerk",
+                                            "o_shippriority",
+                                            "o_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                          }
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "orders"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "expression": {
                                       "scalarFunction": {
-                                        "functionReference": 3,
+                                        "functionReference": 1,
                                         "outputType": {
                                           "bool": {
                                             "nullability": "NULLABILITY_NULLABLE"
@@ -296,7 +270,7 @@
                                           {
                                             "value": {
                                               "scalarFunction": {
-                                                "functionReference": 4,
+                                                "functionReference": 2,
                                                 "outputType": {
                                                   "bool": {
                                                     "nullability": "NULLABILITY_NULLABLE"
@@ -307,9 +281,7 @@
                                                     "value": {
                                                       "selection": {
                                                         "directReference": {
-                                                          "structField": {
-                                                            "field": 16
-                                                          }
+                                                          "structField": {}
                                                         },
                                                         "rootReference": {}
                                                       }
@@ -317,8 +289,60 @@
                                                   },
                                                   {
                                                     "value": {
-                                                      "literal": {
-                                                        "string": "%special%requests%"
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 9
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 4,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 16
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "literal": {
+                                                                "string": "%special%requests%"
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
                                                       }
                                                     }
                                                   }
@@ -328,12 +352,223 @@
                                           }
                                         ]
                                       }
+                                    },
+                                    "type": "JOIN_TYPE_LEFT"
+                                  }
+                                },
+                                "expressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 2
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 3
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 7
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 8
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 9
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 10
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 11
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 12
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 13
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 14
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 15
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 16
+                                        }
+                                      },
+                                      "rootReference": {}
                                     }
                                   }
                                 ]
                               }
                             },
-                            "type": "JOIN_TYPE_LEFT"
+                            "groupings": [
+                              {
+                                "groupingExpressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  }
+                                ]
+                              }
+                            ],
+                            "measures": [
+                              {
+                                "measure": {
+                                  "functionReference": 5,
+                                  "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                  "outputType": {
+                                    "i64": {
+                                      "nullability": "NULLABILITY_NULLABLE"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "value": {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {
+                                              "field": 8
+                                            }
+                                          },
+                                          "rootReference": {}
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
                           }
                         },
                         "expressions": [
@@ -354,156 +589,6 @@
                               },
                               "rootReference": {}
                             }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 2
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 3
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 6
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 7
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 8
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 9
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 10
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 11
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 13
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 14
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 15
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 16
-                                }
-                              },
-                              "rootReference": {}
-                            }
                           }
                         ]
                       }
@@ -514,7 +599,9 @@
                           {
                             "selection": {
                               "directReference": {
-                                "structField": {}
+                                "structField": {
+                                  "field": 1
+                                }
                               },
                               "rootReference": {}
                             }
@@ -531,52 +618,29 @@
                             "i64": {
                               "nullability": "NULLABILITY_NULLABLE"
                             }
-                          },
-                          "arguments": [
-                            {
-                              "value": {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 8
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     ]
                   }
                 },
-                "groupings": [
+                "expressions": [
                   {
-                    "groupingExpressions": [
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 1
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "measures": [
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
+                      },
+                      "rootReference": {}
+                    }
+                  },
                   {
-                    "measure": {
-                      "functionReference": 5,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
-                      }
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h14/tpc_h14.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h14/tpc_h14.json
@@ -106,843 +106,875 @@
                   }
                 },
                 "input": {
-                  "aggregate": {
+                  "project": {
+                    "common": {
+                      "emit": {
+                        "outputMapping": [
+                          2,
+                          3
+                        ]
+                      }
+                    },
                     "input": {
-                      "filter": {
+                      "aggregate": {
                         "input": {
-                          "project": {
-                            "common": {
-                              "emit": {
-                                "outputMapping": [
-                                  25,
-                                  26,
-                                  27,
-                                  28,
-                                  29,
-                                  30,
-                                  31,
-                                  32,
-                                  33,
-                                  34,
-                                  35,
-                                  36,
-                                  37,
-                                  38,
-                                  39,
-                                  40,
-                                  41,
-                                  42,
-                                  43,
-                                  44,
-                                  45,
-                                  46,
-                                  47,
-                                  48,
-                                  49
+                          "filter": {
+                            "input": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      25,
+                                      26,
+                                      27,
+                                      28,
+                                      29,
+                                      30,
+                                      31,
+                                      32,
+                                      33,
+                                      34,
+                                      35,
+                                      36,
+                                      37,
+                                      38,
+                                      39,
+                                      40,
+                                      41,
+                                      42,
+                                      43,
+                                      44,
+                                      45,
+                                      46,
+                                      47,
+                                      48,
+                                      49
+                                    ]
+                                  }
+                                },
+                                "input": {
+                                  "join": {
+                                    "left": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "l_orderkey",
+                                            "l_partkey",
+                                            "l_suppkey",
+                                            "l_linenumber",
+                                            "l_quantity",
+                                            "l_extendedprice",
+                                            "l_discount",
+                                            "l_tax",
+                                            "l_returnflag",
+                                            "l_linestatus",
+                                            "l_shipdate",
+                                            "l_commitdate",
+                                            "l_receiptdate",
+                                            "l_shipinstruct",
+                                            "l_shipmode",
+                                            "l_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                          }
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "lineitem"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "right": {
+                                      "read": {
+                                        "common": {
+                                          "direct": {}
+                                        },
+                                        "baseSchema": {
+                                          "names": [
+                                            "p_partkey",
+                                            "p_name",
+                                            "p_mfgr",
+                                            "p_brand",
+                                            "p_type",
+                                            "p_size",
+                                            "p_container",
+                                            "p_retailprice",
+                                            "p_comment"
+                                          ],
+                                          "struct": {
+                                            "types": [
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "i32": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                }
+                                              }
+                                            ],
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                          }
+                                        },
+                                        "namedTable": {
+                                          "names": [
+                                            "part"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "expression": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 1
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 16
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "JOIN_TYPE_INNER"
+                                  }
+                                },
+                                "expressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 2
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 3
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 7
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 8
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 9
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 10
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 11
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 12
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 13
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 14
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 15
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 16
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 17
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 18
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 19
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 20
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 21
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 22
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 23
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 24
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  }
                                 ]
                               }
                             },
-                            "input": {
-                              "join": {
-                                "left": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "l_orderkey",
-                                        "l_partkey",
-                                        "l_suppkey",
-                                        "l_linenumber",
-                                        "l_quantity",
-                                        "l_extendedprice",
-                                        "l_discount",
-                                        "l_tax",
-                                        "l_returnflag",
-                                        "l_linestatus",
-                                        "l_shipdate",
-                                        "l_commitdate",
-                                        "l_receiptdate",
-                                        "l_shipinstruct",
-                                        "l_shipmode",
-                                        "l_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "lineitem"
-                                      ]
-                                    }
+                            "condition": {
+                              "scalarFunction": {
+                                "functionReference": 2,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
                                   }
                                 },
-                                "right": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "p_partkey",
-                                        "p_name",
-                                        "p_mfgr",
-                                        "p_brand",
-                                        "p_type",
-                                        "p_size",
-                                        "p_container",
-                                        "p_retailprice",
-                                        "p_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 3,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
                                           }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "part"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "expression": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 1
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 10
+                                                  }
+                                                },
+                                                "rootReference": {}
                                               }
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 16
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "literal": {
+                                                "string": "1995-09-01"
                                               }
-                                            },
-                                            "rootReference": {}
+                                            }
                                           }
-                                        }
+                                        ]
                                       }
-                                    ]
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 4,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 10
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "literal": {
+                                                "string": "1995-10-01"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
                                   }
-                                },
-                                "type": "JOIN_TYPE_INNER"
+                                ]
                               }
-                            },
-                            "expressions": [
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {}
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 1
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 2
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 3
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 4
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 5
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 6
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 7
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 8
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 9
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 10
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 11
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 12
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 13
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 14
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 15
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 16
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 17
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 18
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 19
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 20
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 21
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 22
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 23
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 24
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              }
-                            ]
+                            }
                           }
                         },
-                        "condition": {
-                          "scalarFunction": {
-                            "functionReference": 2,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 3,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 10
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "literal": {
-                                            "string": "1995-09-01"
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
+                        "groupings": [
+                          {}
+                        ],
+                        "measures": [
+                          {
+                            "measure": {
+                              "functionReference": 5,
+                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 38,
+                                  "nullability": "NULLABILITY_NULLABLE"
                                 }
                               },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 4,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 10
-                                              }
-                                            },
-                                            "rootReference": {}
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "ifThen": {
+                                      "ifs": [
+                                        {
+                                          "if": {
+                                            "scalarFunction": {
+                                              "functionReference": 6,
+                                              "outputType": {
+                                                "bool": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 20
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "literal": {
+                                                      "string": "PROMO%"
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "then": {
+                                            "scalarFunction": {
+                                              "functionReference": 7,
+                                              "outputType": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 5
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "scalarFunction": {
+                                                      "functionReference": 8,
+                                                      "outputType": {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "arguments": [
+                                                        {
+                                                          "value": {
+                                                            "cast": {
+                                                              "type": {
+                                                                "decimal": {
+                                                                  "scale": 2,
+                                                                  "precision": 15,
+                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                              },
+                                                              "input": {
+                                                                "literal": {
+                                                                  "i8": 1
+                                                                }
+                                                              },
+                                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                            }
+                                                          }
+                                                        },
+                                                        {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 6
+                                                                }
+                                                              },
+                                                              "rootReference": {}
+                                                            }
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
                                           }
                                         }
-                                      },
-                                      {
-                                        "value": {
-                                          "literal": {
-                                            "string": "1995-10-01"
-                                          }
+                                      ],
+                                      "else": {
+                                        "literal": {
+                                          "i8": 0
                                         }
                                       }
-                                    ]
+                                    }
                                   }
                                 }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    },
-                    "groupings": [
-                      {}
-                    ],
-                    "measures": [
-                      {
-                        "measure": {
-                          "functionReference": 5,
-                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 38,
-                              "nullability": "NULLABILITY_NULLABLE"
+                              ]
                             }
                           },
-                          "arguments": [
-                            {
-                              "value": {
-                                "ifThen": {
-                                  "ifs": [
-                                    {
-                                      "if": {
-                                        "scalarFunction": {
-                                          "functionReference": 6,
-                                          "outputType": {
-                                            "bool": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 20
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "value": {
-                                                "literal": {
-                                                  "string": "PROMO%"
-                                                }
-                                              }
-                                            }
-                                          ]
+                          {
+                            "measure": {
+                              "functionReference": 5,
+                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 38,
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 7,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
                                         }
                                       },
-                                      "then": {
-                                        "scalarFunction": {
-                                          "functionReference": 7,
-                                          "outputType": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 5
-                                                    }
-                                                  },
-                                                  "rootReference": {}
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 5
                                                 }
-                                              }
-                                            },
-                                            {
-                                              "value": {
-                                                "scalarFunction": {
-                                                  "functionReference": 8,
-                                                  "outputType": {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  "arguments": [
-                                                    {
-                                                      "value": {
-                                                        "cast": {
-                                                          "type": {
-                                                            "decimal": {
-                                                              "scale": 2,
-                                                              "precision": 15,
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "input": {
-                                                            "literal": {
-                                                              "i8": 1
-                                                            }
-                                                          },
-                                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                        }
-                                                      }
-                                                    },
-                                                    {
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 6
-                                                            }
-                                                          },
-                                                          "rootReference": {}
-                                                        }
-                                                      }
-                                                    }
-                                                  ]
-                                                }
-                                              }
+                                              },
+                                              "rootReference": {}
                                             }
-                                          ]
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "scalarFunction": {
+                                              "functionReference": 8,
+                                              "outputType": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "cast": {
+                                                      "type": {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      "input": {
+                                                        "literal": {
+                                                          "i8": 1
+                                                        }
+                                                      },
+                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 6
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
                                         }
-                                      }
-                                    }
-                                  ],
-                                  "else": {
-                                    "literal": {
-                                      "i8": 0
+                                      ]
                                     }
                                   }
                                 }
-                              }
+                              ]
                             }
-                          ]
+                          }
+                        ]
+                      }
+                    },
+                    "expressions": [
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {}
+                          },
+                          "rootReference": {}
                         }
                       },
                       {
-                        "measure": {
-                          "functionReference": 5,
-                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 38,
-                              "nullability": "NULLABILITY_NULLABLE"
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
                             }
                           },
-                          "arguments": [
-                            {
-                              "value": {
-                                "scalarFunction": {
-                                  "functionReference": 7,
-                                  "outputType": {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "value": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 5
-                                            }
-                                          },
-                                          "rootReference": {}
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "value": {
-                                        "scalarFunction": {
-                                          "functionReference": 8,
-                                          "outputType": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "cast": {
-                                                  "type": {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  "input": {
-                                                    "literal": {
-                                                      "i8": 1
-                                                    }
-                                                  },
-                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 6
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          ]
+                          "rootReference": {}
                         }
                       }
                     ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h15/tpc_h15.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h15/tpc_h15.json
@@ -176,319 +176,351 @@
                               }
                             },
                             "right": {
-                              "aggregate": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      2,
+                                      3
+                                    ]
+                                  }
+                                },
                                 "input": {
-                                  "filter": {
+                                  "aggregate": {
                                     "input": {
-                                      "read": {
-                                        "common": {
-                                          "direct": {}
-                                        },
-                                        "baseSchema": {
-                                          "names": [
-                                            "l_orderkey",
-                                            "l_partkey",
-                                            "l_suppkey",
-                                            "l_linenumber",
-                                            "l_quantity",
-                                            "l_extendedprice",
-                                            "l_discount",
-                                            "l_tax",
-                                            "l_returnflag",
-                                            "l_linestatus",
-                                            "l_shipdate",
-                                            "l_commitdate",
-                                            "l_receiptdate",
-                                            "l_shipinstruct",
-                                            "l_shipmode",
-                                            "l_comment"
-                                          ],
-                                          "struct": {
-                                            "types": [
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "i64": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
+                                      "filter": {
+                                        "input": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "l_orderkey",
+                                                "l_partkey",
+                                                "l_suppkey",
+                                                "l_linenumber",
+                                                "l_quantity",
+                                                "l_extendedprice",
+                                                "l_discount",
+                                                "l_tax",
+                                                "l_returnflag",
+                                                "l_linestatus",
+                                                "l_shipdate",
+                                                "l_commitdate",
+                                                "l_receiptdate",
+                                                "l_shipinstruct",
+                                                "l_shipmode",
+                                                "l_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i64": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
                                               }
-                                            ],
-                                            "nullability": "NULLABILITY_REQUIRED"
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "lineitem"
+                                              ]
+                                            }
                                           }
                                         },
-                                        "namedTable": {
-                                          "names": [
-                                            "lineitem"
-                                          ]
+                                        "condition": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 2,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 10
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "literal": {
+                                                            "string": "1996-01-01"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 3,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 10
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "literal": {
+                                                            "string": "1996-04-01"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
                                         }
                                       }
                                     },
-                                    "condition": {
-                                      "scalarFunction": {
-                                        "functionReference": 1,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
+                                    "groupings": [
+                                      {
+                                        "groupingExpressions": [
                                           {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 2,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 10
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "literal": {
-                                                        "string": "1996-01-01"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 3,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 10
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "literal": {
-                                                        "string": "1996-04-01"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 2
+                                                }
+                                              },
+                                              "rootReference": {}
                                             }
                                           }
                                         ]
                                       }
-                                    }
-                                  }
-                                },
-                                "groupings": [
-                                  {
-                                    "groupingExpressions": [
+                                    ],
+                                    "measures": [
                                       {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 2
+                                        "measure": {
+                                          "functionReference": 4,
+                                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                          "outputType": {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 38,
+                                              "nullability": "NULLABILITY_NULLABLE"
                                             }
                                           },
-                                          "rootReference": {}
+                                          "arguments": [
+                                            {
+                                              "value": {
+                                                "scalarFunction": {
+                                                  "functionReference": 5,
+                                                  "outputType": {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                  },
+                                                  "arguments": [
+                                                    {
+                                                      "value": {
+                                                        "selection": {
+                                                          "directReference": {
+                                                            "structField": {
+                                                              "field": 5
+                                                            }
+                                                          },
+                                                          "rootReference": {}
+                                                        }
+                                                      }
+                                                    },
+                                                    {
+                                                      "value": {
+                                                        "scalarFunction": {
+                                                          "functionReference": 6,
+                                                          "outputType": {
+                                                            "decimal": {
+                                                              "scale": 2,
+                                                              "precision": 15,
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "arguments": [
+                                                            {
+                                                              "value": {
+                                                                "cast": {
+                                                                  "type": {
+                                                                    "decimal": {
+                                                                      "scale": 2,
+                                                                      "precision": 15,
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "input": {
+                                                                    "literal": {
+                                                                      "i8": 1
+                                                                    }
+                                                                  },
+                                                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "value": {
+                                                                "selection": {
+                                                                  "directReference": {
+                                                                    "structField": {
+                                                                      "field": 6
+                                                                    }
+                                                                  },
+                                                                  "rootReference": {}
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          ]
                                         }
                                       }
                                     ]
                                   }
-                                ],
-                                "measures": [
+                                },
+                                "expressions": [
                                   {
-                                    "measure": {
-                                      "functionReference": 4,
-                                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                      "outputType": {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 38,
-                                          "nullability": "NULLABILITY_NULLABLE"
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
                                         }
                                       },
-                                      "arguments": [
-                                        {
-                                          "value": {
-                                            "scalarFunction": {
-                                              "functionReference": 5,
-                                              "outputType": {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                }
-                                              },
-                                              "arguments": [
-                                                {
-                                                  "value": {
-                                                    "selection": {
-                                                      "directReference": {
-                                                        "structField": {
-                                                          "field": 5
-                                                        }
-                                                      },
-                                                      "rootReference": {}
-                                                    }
-                                                  }
-                                                },
-                                                {
-                                                  "value": {
-                                                    "scalarFunction": {
-                                                      "functionReference": 6,
-                                                      "outputType": {
-                                                        "decimal": {
-                                                          "scale": 2,
-                                                          "precision": 15,
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "arguments": [
-                                                        {
-                                                          "value": {
-                                                            "cast": {
-                                                              "type": {
-                                                                "decimal": {
-                                                                  "scale": 2,
-                                                                  "precision": 15,
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "input": {
-                                                                "literal": {
-                                                                  "i8": 1
-                                                                }
-                                                              },
-                                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                            }
-                                                          }
-                                                        },
-                                                        {
-                                                          "value": {
-                                                            "selection": {
-                                                              "directReference": {
-                                                                "structField": {
-                                                                  "field": 6
-                                                                }
-                                                              },
-                                                              "rootReference": {}
-                                                            }
-                                                          }
-                                                        }
-                                                      ]
-                                                    }
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        }
-                                      ]
+                                      "rootReference": {}
                                     }
                                   }
                                 ]
@@ -649,357 +681,352 @@
                               "subquery": {
                                 "scalar": {
                                   "input": {
-                                    "aggregate": {
+                                    "project": {
+                                      "common": {
+                                        "emit": {
+                                          "outputMapping": [
+                                            1
+                                          ]
+                                        }
+                                      },
                                       "input": {
-                                        "project": {
-                                          "common": {
-                                            "emit": {
-                                              "outputMapping": [
-                                                9,
-                                                10,
-                                                11,
-                                                12,
-                                                13,
-                                                14,
-                                                15,
-                                                16,
-                                                17
-                                              ]
-                                            }
-                                          },
+                                        "aggregate": {
                                           "input": {
-                                            "join": {
-                                              "left": {
-                                                "read": {
-                                                  "common": {
-                                                    "direct": {}
-                                                  },
-                                                  "baseSchema": {
-                                                    "names": [
-                                                      "s_suppkey",
-                                                      "s_name",
-                                                      "s_address",
-                                                      "s_nationkey",
-                                                      "s_phone",
-                                                      "s_acctbal",
-                                                      "s_comment"
-                                                    ],
-                                                    "struct": {
-                                                      "types": [
-                                                        {
-                                                          "i32": {
-                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                          }
-                                                        },
-                                                        {
-                                                          "i32": {
-                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                          }
-                                                        },
-                                                        {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 15,
-                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                          }
-                                                        },
-                                                        {
-                                                          "string": {
-                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                          }
-                                                        }
-                                                      ],
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  "namedTable": {
-                                                    "names": [
-                                                      "supplier"
-                                                    ]
-                                                  }
+                                            "project": {
+                                              "common": {
+                                                "emit": {
+                                                  "outputMapping": [
+                                                    9,
+                                                    10,
+                                                    11,
+                                                    12,
+                                                    13,
+                                                    14,
+                                                    15,
+                                                    16,
+                                                    17
+                                                  ]
                                                 }
                                               },
-                                              "right": {
-                                                "aggregate": {
-                                                  "input": {
-                                                    "filter": {
-                                                      "input": {
-                                                        "read": {
-                                                          "common": {
-                                                            "direct": {}
-                                                          },
-                                                          "baseSchema": {
-                                                            "names": [
-                                                              "l_orderkey",
-                                                              "l_partkey",
-                                                              "l_suppkey",
-                                                              "l_linenumber",
-                                                              "l_quantity",
-                                                              "l_extendedprice",
-                                                              "l_discount",
-                                                              "l_tax",
-                                                              "l_returnflag",
-                                                              "l_linestatus",
-                                                              "l_shipdate",
-                                                              "l_commitdate",
-                                                              "l_receiptdate",
-                                                              "l_shipinstruct",
-                                                              "l_shipmode",
-                                                              "l_comment"
-                                                            ],
-                                                            "struct": {
-                                                              "types": [
-                                                                {
-                                                                  "i64": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "i64": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "i64": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "i64": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "decimal": {
-                                                                    "scale": 2,
-                                                                    "precision": 15,
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "decimal": {
-                                                                    "scale": 2,
-                                                                    "precision": 15,
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "decimal": {
-                                                                    "scale": 2,
-                                                                    "precision": 15,
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "decimal": {
-                                                                    "scale": 2,
-                                                                    "precision": 15,
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "date": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "date": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "date": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "string": {
-                                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                                  }
-                                                                }
-                                                              ],
-                                                              "nullability": "NULLABILITY_REQUIRED"
-                                                            }
-                                                          },
-                                                          "namedTable": {
-                                                            "names": [
-                                                              "lineitem"
-                                                            ]
-                                                          }
-                                                        }
+                                              "input": {
+                                                "join": {
+                                                  "left": {
+                                                    "read": {
+                                                      "common": {
+                                                        "direct": {}
                                                       },
-                                                      "condition": {
-                                                        "scalarFunction": {
-                                                          "functionReference": 1,
-                                                          "outputType": {
-                                                            "bool": {
-                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                            }
-                                                          },
-                                                          "arguments": [
+                                                      "baseSchema": {
+                                                        "names": [
+                                                          "s_suppkey",
+                                                          "s_name",
+                                                          "s_address",
+                                                          "s_nationkey",
+                                                          "s_phone",
+                                                          "s_acctbal",
+                                                          "s_comment"
+                                                        ],
+                                                        "struct": {
+                                                          "types": [
                                                             {
-                                                              "value": {
-                                                                "scalarFunction": {
-                                                                  "functionReference": 2,
-                                                                  "outputType": {
-                                                                    "bool": {
-                                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                                    }
-                                                                  },
-                                                                  "arguments": [
-                                                                    {
-                                                                      "value": {
-                                                                        "selection": {
-                                                                          "directReference": {
-                                                                            "structField": {
-                                                                              "field": 10
-                                                                            }
-                                                                          },
-                                                                          "rootReference": {}
-                                                                        }
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "value": {
-                                                                        "literal": {
-                                                                          "string": "1996-01-01"
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  ]
-                                                                }
+                                                              "i32": {
+                                                                "nullability": "NULLABILITY_REQUIRED"
                                                               }
                                                             },
                                                             {
-                                                              "value": {
-                                                                "scalarFunction": {
-                                                                  "functionReference": 3,
-                                                                  "outputType": {
-                                                                    "bool": {
-                                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                                    }
-                                                                  },
-                                                                  "arguments": [
-                                                                    {
-                                                                      "value": {
-                                                                        "selection": {
-                                                                          "directReference": {
-                                                                            "structField": {
-                                                                              "field": 10
-                                                                            }
-                                                                          },
-                                                                          "rootReference": {}
-                                                                        }
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "value": {
-                                                                        "literal": {
-                                                                          "string": "1996-04-01"
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  ]
-                                                                }
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                              }
+                                                            },
+                                                            {
+                                                              "i32": {
+                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_REQUIRED"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_REQUIRED"
                                                               }
                                                             }
-                                                          ]
+                                                          ],
+                                                          "nullability": "NULLABILITY_REQUIRED"
                                                         }
+                                                      },
+                                                      "namedTable": {
+                                                        "names": [
+                                                          "supplier"
+                                                        ]
                                                       }
                                                     }
                                                   },
-                                                  "groupings": [
-                                                    {
-                                                      "groupingExpressions": [
-                                                        {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 2
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
+                                                  "right": {
+                                                    "project": {
+                                                      "common": {
+                                                        "emit": {
+                                                          "outputMapping": [
+                                                            2,
+                                                            3
+                                                          ]
                                                         }
-                                                      ]
-                                                    }
-                                                  ],
-                                                  "measures": [
-                                                    {
-                                                      "measure": {
-                                                        "functionReference": 4,
-                                                        "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                        "outputType": {
-                                                          "decimal": {
-                                                            "scale": 2,
-                                                            "precision": 38,
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        "arguments": [
-                                                          {
-                                                            "value": {
-                                                              "scalarFunction": {
-                                                                "functionReference": 5,
+                                                      },
+                                                      "input": {
+                                                        "aggregate": {
+                                                          "input": {
+                                                            "filter": {
+                                                              "input": {
+                                                                "read": {
+                                                                  "common": {
+                                                                    "direct": {}
+                                                                  },
+                                                                  "baseSchema": {
+                                                                    "names": [
+                                                                      "l_orderkey",
+                                                                      "l_partkey",
+                                                                      "l_suppkey",
+                                                                      "l_linenumber",
+                                                                      "l_quantity",
+                                                                      "l_extendedprice",
+                                                                      "l_discount",
+                                                                      "l_tax",
+                                                                      "l_returnflag",
+                                                                      "l_linestatus",
+                                                                      "l_shipdate",
+                                                                      "l_commitdate",
+                                                                      "l_receiptdate",
+                                                                      "l_shipinstruct",
+                                                                      "l_shipmode",
+                                                                      "l_comment"
+                                                                    ],
+                                                                    "struct": {
+                                                                      "types": [
+                                                                        {
+                                                                          "i64": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "i64": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "i64": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "i64": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "date": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "date": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "date": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "string": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        }
+                                                                      ],
+                                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                                    }
+                                                                  },
+                                                                  "namedTable": {
+                                                                    "names": [
+                                                                      "lineitem"
+                                                                    ]
+                                                                  }
+                                                                }
+                                                              },
+                                                              "condition": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 1,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "scalarFunction": {
+                                                                          "functionReference": 2,
+                                                                          "outputType": {
+                                                                            "bool": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          "arguments": [
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
+                                                                                      "field": 10
+                                                                                    }
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "value": {
+                                                                                "literal": {
+                                                                                  "string": "1996-01-01"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "scalarFunction": {
+                                                                          "functionReference": 3,
+                                                                          "outputType": {
+                                                                            "bool": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          "arguments": [
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
+                                                                                      "field": 10
+                                                                                    }
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "value": {
+                                                                                "literal": {
+                                                                                  "string": "1996-04-01"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "groupings": [
+                                                            {
+                                                              "groupingExpressions": [
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 2
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          ],
+                                                          "measures": [
+                                                            {
+                                                              "measure": {
+                                                                "functionReference": 4,
+                                                                "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                                                                 "outputType": {
                                                                   "decimal": {
                                                                     "scale": 2,
-                                                                    "precision": 15,
+                                                                    "precision": 38,
                                                                     "nullability": "NULLABILITY_NULLABLE"
                                                                   }
                                                                 },
                                                                 "arguments": [
                                                                   {
                                                                     "value": {
-                                                                      "selection": {
-                                                                        "directReference": {
-                                                                          "structField": {
-                                                                            "field": 5
-                                                                          }
-                                                                        },
-                                                                        "rootReference": {}
-                                                                      }
-                                                                    }
-                                                                  },
-                                                                  {
-                                                                    "value": {
                                                                       "scalarFunction": {
-                                                                        "functionReference": 6,
+                                                                        "functionReference": 5,
                                                                         "outputType": {
                                                                           "decimal": {
                                                                             "scale": 2,
@@ -1010,32 +1037,60 @@
                                                                         "arguments": [
                                                                           {
                                                                             "value": {
-                                                                              "cast": {
-                                                                                "type": {
+                                                                              "selection": {
+                                                                                "directReference": {
+                                                                                  "structField": {
+                                                                                    "field": 5
+                                                                                  }
+                                                                                },
+                                                                                "rootReference": {}
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "scalarFunction": {
+                                                                                "functionReference": 6,
+                                                                                "outputType": {
                                                                                   "decimal": {
                                                                                     "scale": 2,
                                                                                     "precision": 15,
                                                                                     "nullability": "NULLABILITY_NULLABLE"
                                                                                   }
                                                                                 },
-                                                                                "input": {
-                                                                                  "literal": {
-                                                                                    "i8": 1
+                                                                                "arguments": [
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "cast": {
+                                                                                        "type": {
+                                                                                          "decimal": {
+                                                                                            "scale": 2,
+                                                                                            "precision": 15,
+                                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                        },
+                                                                                        "input": {
+                                                                                          "literal": {
+                                                                                            "i8": 1
+                                                                                          }
+                                                                                        },
+                                                                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "selection": {
+                                                                                        "directReference": {
+                                                                                          "structField": {
+                                                                                            "field": 6
+                                                                                          }
+                                                                                        },
+                                                                                        "rootReference": {}
+                                                                                      }
+                                                                                    }
                                                                                   }
-                                                                                },
-                                                                                "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                                              }
-                                                                            }
-                                                                          },
-                                                                          {
-                                                                            "value": {
-                                                                              "selection": {
-                                                                                "directReference": {
-                                                                                  "structField": {
-                                                                                    "field": 6
-                                                                                  }
-                                                                                },
-                                                                                "rootReference": {}
+                                                                                ]
                                                                               }
                                                                             }
                                                                           }
@@ -1046,160 +1101,148 @@
                                                                 ]
                                                               }
                                                             }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "expressions": [
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {}
+                                                            },
+                                                            "rootReference": {}
                                                           }
-                                                        ]
-                                                      }
-                                                    }
-                                                  ]
-                                                }
-                                              },
-                                              "expression": {
-                                                "scalarFunction": {
-                                                  "functionReference": 7,
-                                                  "outputType": {
-                                                    "bool": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                        },
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 1
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      ]
                                                     }
                                                   },
-                                                  "arguments": [
-                                                    {
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {}
-                                                          },
-                                                          "rootReference": {}
+                                                  "expression": {
+                                                    "scalarFunction": {
+                                                      "functionReference": 7,
+                                                      "outputType": {
+                                                        "bool": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
                                                         }
-                                                      }
-                                                    },
-                                                    {
-                                                      "value": {
-                                                        "selection": {
-                                                          "directReference": {
-                                                            "structField": {
-                                                              "field": 7
+                                                      },
+                                                      "arguments": [
+                                                        {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {}
+                                                              },
+                                                              "rootReference": {}
                                                             }
-                                                          },
-                                                          "rootReference": {}
+                                                          }
+                                                        },
+                                                        {
+                                                          "value": {
+                                                            "selection": {
+                                                              "directReference": {
+                                                                "structField": {
+                                                                  "field": 7
+                                                                }
+                                                              },
+                                                              "rootReference": {}
+                                                            }
+                                                          }
                                                         }
-                                                      }
+                                                      ]
                                                     }
-                                                  ]
+                                                  },
+                                                  "type": "JOIN_TYPE_INNER"
                                                 }
                                               },
-                                              "type": "JOIN_TYPE_INNER"
-                                            }
-                                          },
-                                          "expressions": [
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {}
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 1
+                                              "expressions": [
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {}
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 2
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 1
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 3
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 2
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 4
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 3
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 5
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 4
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 6
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 5
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 7
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 6
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            },
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 8
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 7
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
                                                 },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      "groupings": [
-                                        {}
-                                      ],
-                                      "measures": [
-                                        {
-                                          "measure": {
-                                            "functionReference": 8,
-                                            "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                            "outputType": {
-                                              "decimal": {
-                                                "scale": 2,
-                                                "precision": 38,
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
+                                                {
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
@@ -1209,8 +1252,50 @@
                                                     "rootReference": {}
                                                   }
                                                 }
+                                              ]
+                                            }
+                                          },
+                                          "groupings": [
+                                            {}
+                                          ],
+                                          "measures": [
+                                            {
+                                              "measure": {
+                                                "functionReference": 8,
+                                                "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                "outputType": {
+                                                  "decimal": {
+                                                    "scale": 2,
+                                                    "precision": 38,
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 8
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
                                               }
-                                            ]
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "expressions": [
+                                        {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {}
+                                            },
+                                            "rootReference": {}
                                           }
                                         }
                                       ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h16/tpc_h16.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h16/tpc_h16.json
@@ -67,279 +67,692 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      4,
+                      5,
+                      6,
+                      7
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "project": {
-                        "common": {
-                          "emit": {
-                            "outputMapping": [
-                              14,
-                              15,
-                              16,
-                              17,
-                              18,
-                              19,
-                              20,
-                              21,
-                              22,
-                              23,
-                              24,
-                              25,
-                              26,
-                              27
-                            ]
-                          }
-                        },
+                      "filter": {
                         "input": {
-                          "join": {
-                            "left": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "ps_partkey",
-                                    "ps_suppkey",
-                                    "ps_availqty",
-                                    "ps_supplycost",
-                                    "ps_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "partsupp"
-                                  ]
-                                }
-                              }
-                            },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "p_partkey",
-                                    "p_name",
-                                    "p_mfgr",
-                                    "p_brand",
-                                    "p_type",
-                                    "p_size",
-                                    "p_container",
-                                    "p_retailprice",
-                                    "p_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "part"
-                                  ]
-                                }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 5
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {}
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  }
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  14,
+                                  15,
+                                  16,
+                                  17,
+                                  18,
+                                  19,
+                                  20,
+                                  21,
+                                  22,
+                                  23,
+                                  24,
+                                  25,
+                                  26,
+                                  27
                                 ]
                               }
                             },
-                            "type": "JOIN_TYPE_INNER"
+                            "input": {
+                              "join": {
+                                "left": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "ps_partkey",
+                                        "ps_suppkey",
+                                        "ps_availqty",
+                                        "ps_supplycost",
+                                        "ps_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "partsupp"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "right": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "p_partkey",
+                                        "p_name",
+                                        "p_mfgr",
+                                        "p_brand",
+                                        "p_type",
+                                        "p_size",
+                                        "p_container",
+                                        "p_retailprice",
+                                        "p_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "part"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "expression": {
+                                  "scalarFunction": {
+                                    "functionReference": 1,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 5
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {}
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "JOIN_TYPE_INNER"
+                              }
+                            },
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
+                            ]
                           }
                         },
-                        "expressions": [
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 2,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 2,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 3,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 8
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "literal": {
+                                                            "string": "Brand#45"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 4,
+                                                    "outputType": {
+                                                      "bool": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "scalarFunction": {
+                                                            "functionReference": 5,
+                                                            "outputType": {
+                                                              "bool": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            "arguments": [
+                                                              {
+                                                                "value": {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {
+                                                                        "field": 9
+                                                                      }
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                }
+                                                              },
+                                                              {
+                                                                "value": {
+                                                                  "literal": {
+                                                                    "string": "MEDIUM POLISHED%"
+                                                                  }
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "singularOrList": {
+                                            "value": {
+                                              "selection": {
+                                                "directReference": {
+                                                  "structField": {
+                                                    "field": 10
+                                                  }
+                                                },
+                                                "rootReference": {}
+                                              }
+                                            },
+                                            "options": [
+                                              {
+                                                "literal": {
+                                                  "i8": 49
+                                                }
+                                              },
+                                              {
+                                                "literal": {
+                                                  "i8": 14
+                                                }
+                                              },
+                                              {
+                                                "literal": {
+                                                  "i8": 23
+                                                }
+                                              },
+                                              {
+                                                "literal": {
+                                                  "i8": 45
+                                                }
+                                              },
+                                              {
+                                                "literal": {
+                                                  "i8": 19
+                                                }
+                                              },
+                                              {
+                                                "literal": {
+                                                  "i8": 3
+                                                }
+                                              },
+                                              {
+                                                "literal": {
+                                                  "i8": 36
+                                                }
+                                              },
+                                              {
+                                                "literal": {
+                                                  "i8": 9
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
                                 }
                               },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 2
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 4,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "subquery": {
+                                            "inPredicate": {
+                                              "needles": [
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 1
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              ],
+                                              "haystack": {
+                                                "project": {
+                                                  "common": {
+                                                    "emit": {
+                                                      "outputMapping": [
+                                                        7
+                                                      ]
+                                                    }
+                                                  },
+                                                  "input": {
+                                                    "filter": {
+                                                      "input": {
+                                                        "read": {
+                                                          "common": {
+                                                            "direct": {}
+                                                          },
+                                                          "baseSchema": {
+                                                            "names": [
+                                                              "s_suppkey",
+                                                              "s_name",
+                                                              "s_address",
+                                                              "s_nationkey",
+                                                              "s_phone",
+                                                              "s_acctbal",
+                                                              "s_comment"
+                                                            ],
+                                                            "struct": {
+                                                              "types": [
+                                                                {
+                                                                  "i32": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i32": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          "namedTable": {
+                                                            "names": [
+                                                              "supplier"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "condition": {
+                                                        "scalarFunction": {
+                                                          "functionReference": 5,
+                                                          "outputType": {
+                                                            "bool": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "arguments": [
+                                                            {
+                                                              "value": {
+                                                                "selection": {
+                                                                  "directReference": {
+                                                                    "structField": {
+                                                                      "field": 6
+                                                                    }
+                                                                  },
+                                                                  "rootReference": {}
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "value": {
+                                                                "literal": {
+                                                                  "string": "%Customer%Complaints%"
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "expressions": [
+                                                    {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
                                 }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 3
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 6
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 7
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "groupings": [
+                      {
+                        "groupingExpressions": [
                           {
                             "selection": {
                               "directReference": {
@@ -369,436 +782,77 @@
                               },
                               "rootReference": {}
                             }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 11
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 13
-                                }
-                              },
-                              "rootReference": {}
-                            }
                           }
                         ]
                       }
-                    },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 2,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 2,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 2,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 3,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 8
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "literal": {
-                                                        "string": "Brand#45"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "scalarFunction": {
-                                                "functionReference": 4,
-                                                "outputType": {
-                                                  "bool": {
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "scalarFunction": {
-                                                        "functionReference": 5,
-                                                        "outputType": {
-                                                          "bool": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        "arguments": [
-                                                          {
-                                                            "value": {
-                                                              "selection": {
-                                                                "directReference": {
-                                                                  "structField": {
-                                                                    "field": 9
-                                                                  }
-                                                                },
-                                                                "rootReference": {}
-                                                              }
-                                                            }
-                                                          },
-                                                          {
-                                                            "value": {
-                                                              "literal": {
-                                                                "string": "MEDIUM POLISHED%"
-                                                              }
-                                                            }
-                                                          }
-                                                        ]
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
+                    ],
+                    "measures": [
+                      {
+                        "measure": {
+                          "functionReference": 6,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "invocation": "AGGREGATION_INVOCATION_DISTINCT",
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
                                     }
                                   },
-                                  {
-                                    "value": {
-                                      "singularOrList": {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 10
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
-                                        },
-                                        "options": [
-                                          {
-                                            "literal": {
-                                              "i8": 49
-                                            }
-                                          },
-                                          {
-                                            "literal": {
-                                              "i8": 14
-                                            }
-                                          },
-                                          {
-                                            "literal": {
-                                              "i8": 23
-                                            }
-                                          },
-                                          {
-                                            "literal": {
-                                              "i8": 45
-                                            }
-                                          },
-                                          {
-                                            "literal": {
-                                              "i8": 19
-                                            }
-                                          },
-                                          {
-                                            "literal": {
-                                              "i8": 3
-                                            }
-                                          },
-                                          {
-                                            "literal": {
-                                              "i8": 36
-                                            }
-                                          },
-                                          {
-                                            "literal": {
-                                              "i8": 9
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  }
-                                ]
+                                  "rootReference": {}
+                                }
                               }
                             }
-                          },
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 4,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "subquery": {
-                                        "inPredicate": {
-                                          "needles": [
-                                            {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 1
-                                                  }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          ],
-                                          "haystack": {
-                                            "project": {
-                                              "common": {
-                                                "emit": {
-                                                  "outputMapping": [
-                                                    7
-                                                  ]
-                                                }
-                                              },
-                                              "input": {
-                                                "filter": {
-                                                  "input": {
-                                                    "read": {
-                                                      "common": {
-                                                        "direct": {}
-                                                      },
-                                                      "baseSchema": {
-                                                        "names": [
-                                                          "s_suppkey",
-                                                          "s_name",
-                                                          "s_address",
-                                                          "s_nationkey",
-                                                          "s_phone",
-                                                          "s_acctbal",
-                                                          "s_comment"
-                                                        ],
-                                                        "struct": {
-                                                          "types": [
-                                                            {
-                                                              "i32": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i32": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            }
-                                                          ],
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      "namedTable": {
-                                                        "names": [
-                                                          "supplier"
-                                                        ]
-                                                      }
-                                                    }
-                                                  },
-                                                  "condition": {
-                                                    "scalarFunction": {
-                                                      "functionReference": 5,
-                                                      "outputType": {
-                                                        "bool": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "arguments": [
-                                                        {
-                                                          "value": {
-                                                            "selection": {
-                                                              "directReference": {
-                                                                "structField": {
-                                                                  "field": 6
-                                                                }
-                                                              },
-                                                              "rootReference": {}
-                                                            }
-                                                          }
-                                                        },
-                                                        {
-                                                          "value": {
-                                                            "literal": {
-                                                              "string": "%Customer%Complaints%"
-                                                            }
-                                                          }
-                                                        }
-                                                      ]
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "expressions": [
-                                                {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {}
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  }
-                },
-                "groupings": [
-                  {
-                    "groupingExpressions": [
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 8
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 9
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 10
-                            }
-                          },
-                          "rootReference": {}
+                          ]
                         }
                       }
                     ]
                   }
-                ],
-                "measures": [
+                },
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 6,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
                       },
-                      "invocation": "AGGREGATION_INVOCATION_DISTINCT",
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 2
                         }
-                      ]
+                      },
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 3
+                        }
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h17/tpc_h17.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h17/tpc_h17.json
@@ -77,930 +77,972 @@
               }
             },
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      1
+                    ]
+                  }
+                },
                 "input": {
-                  "filter": {
+                  "aggregate": {
                     "input": {
-                      "project": {
-                        "common": {
-                          "emit": {
-                            "outputMapping": [
-                              25,
-                              26,
-                              27,
-                              28,
-                              29,
-                              30,
-                              31,
-                              32,
-                              33,
-                              34,
-                              35,
-                              36,
-                              37,
-                              38,
-                              39,
-                              40,
-                              41,
-                              42,
-                              43,
-                              44,
-                              45,
-                              46,
-                              47,
-                              48,
-                              49
+                      "filter": {
+                        "input": {
+                          "project": {
+                            "common": {
+                              "emit": {
+                                "outputMapping": [
+                                  25,
+                                  26,
+                                  27,
+                                  28,
+                                  29,
+                                  30,
+                                  31,
+                                  32,
+                                  33,
+                                  34,
+                                  35,
+                                  36,
+                                  37,
+                                  38,
+                                  39,
+                                  40,
+                                  41,
+                                  42,
+                                  43,
+                                  44,
+                                  45,
+                                  46,
+                                  47,
+                                  48,
+                                  49
+                                ]
+                              }
+                            },
+                            "input": {
+                              "join": {
+                                "left": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "l_orderkey",
+                                        "l_partkey",
+                                        "l_suppkey",
+                                        "l_linenumber",
+                                        "l_quantity",
+                                        "l_extendedprice",
+                                        "l_discount",
+                                        "l_tax",
+                                        "l_returnflag",
+                                        "l_linestatus",
+                                        "l_shipdate",
+                                        "l_commitdate",
+                                        "l_receiptdate",
+                                        "l_shipinstruct",
+                                        "l_shipmode",
+                                        "l_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "i64": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "date": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_NULLABLE"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "lineitem"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "right": {
+                                  "read": {
+                                    "common": {
+                                      "direct": {}
+                                    },
+                                    "baseSchema": {
+                                      "names": [
+                                        "p_partkey",
+                                        "p_name",
+                                        "p_mfgr",
+                                        "p_brand",
+                                        "p_type",
+                                        "p_size",
+                                        "p_container",
+                                        "p_retailprice",
+                                        "p_comment"
+                                      ],
+                                      "struct": {
+                                        "types": [
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "i32": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "decimal": {
+                                              "scale": 2,
+                                              "precision": 15,
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          },
+                                          {
+                                            "string": {
+                                              "nullability": "NULLABILITY_REQUIRED"
+                                            }
+                                          }
+                                        ],
+                                        "nullability": "NULLABILITY_REQUIRED"
+                                      }
+                                    },
+                                    "namedTable": {
+                                      "names": [
+                                        "part"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "expression": {
+                                  "scalarFunction": {
+                                    "functionReference": 1,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 16
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 1
+                                              }
+                                            },
+                                            "rootReference": {}
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "JOIN_TYPE_INNER"
+                              }
+                            },
+                            "expressions": [
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {}
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 1
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 2
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 3
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 4
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 6
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 7
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 8
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 9
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 10
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 11
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 12
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 13
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 14
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 15
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 16
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 17
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 18
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 19
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 20
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 21
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 22
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 23
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              },
+                              {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 24
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
+                              }
                             ]
                           }
                         },
-                        "input": {
-                          "join": {
-                            "left": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "l_orderkey",
-                                    "l_partkey",
-                                    "l_suppkey",
-                                    "l_linenumber",
-                                    "l_quantity",
-                                    "l_extendedprice",
-                                    "l_discount",
-                                    "l_tax",
-                                    "l_returnflag",
-                                    "l_linestatus",
-                                    "l_shipdate",
-                                    "l_commitdate",
-                                    "l_receiptdate",
-                                    "l_shipinstruct",
-                                    "l_shipmode",
-                                    "l_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "i64": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "date": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_NULLABLE"
-                                        }
-                                      }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "lineitem"
-                                  ]
-                                }
+                        "condition": {
+                          "scalarFunction": {
+                            "functionReference": 2,
+                            "outputType": {
+                              "bool": {
+                                "nullability": "NULLABILITY_NULLABLE"
                               }
                             },
-                            "right": {
-                              "read": {
-                                "common": {
-                                  "direct": {}
-                                },
-                                "baseSchema": {
-                                  "names": [
-                                    "p_partkey",
-                                    "p_name",
-                                    "p_mfgr",
-                                    "p_brand",
-                                    "p_type",
-                                    "p_size",
-                                    "p_container",
-                                    "p_retailprice",
-                                    "p_comment"
-                                  ],
-                                  "struct": {
-                                    "types": [
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "i32": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "decimal": {
-                                          "scale": 2,
-                                          "precision": 15,
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
-                                      },
-                                      {
-                                        "string": {
-                                          "nullability": "NULLABILITY_REQUIRED"
-                                        }
+                            "arguments": [
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 2,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
                                       }
-                                    ],
-                                    "nullability": "NULLABILITY_REQUIRED"
-                                  }
-                                },
-                                "namedTable": {
-                                  "names": [
-                                    "part"
-                                  ]
-                                }
-                              }
-                            },
-                            "expression": {
-                              "scalarFunction": {
-                                "functionReference": 1,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 16
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 1
-                                          }
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "type": "JOIN_TYPE_INNER"
-                          }
-                        },
-                        "expressions": [
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 2
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 3
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 4
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 6
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 7
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 8
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 9
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 10
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 11
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 13
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 14
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 15
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 16
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 17
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 18
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 19
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 20
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 21
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 22
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 23
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 24
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "condition": {
-                      "scalarFunction": {
-                        "functionReference": 2,
-                        "outputType": {
-                          "bool": {
-                            "nullability": "NULLABILITY_NULLABLE"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 2,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 1,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 19
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 19
+                                                      }
+                                                    },
+                                                    "rootReference": {}
                                                   }
-                                                },
-                                                "rootReference": {}
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "literal": {
-                                                "string": "Brand#23"
-                                              }
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 1,
-                                        "outputType": {
-                                          "bool": {
-                                            "nullability": "NULLABILITY_NULLABLE"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "selection": {
-                                                "directReference": {
-                                                  "structField": {
-                                                    "field": 22
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "literal": {
+                                                    "string": "Brand#23"
                                                   }
-                                                },
-                                                "rootReference": {}
+                                                }
                                               }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "literal": {
-                                                "string": "MED BOX"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
                                               }
-                                            }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 22
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "literal": {
+                                                    "string": "MED BOX"
+                                                  }
+                                                }
+                                              }
+                                            ]
                                           }
-                                        ]
+                                        }
                                       }
-                                    }
+                                    ]
                                   }
-                                ]
-                              }
-                            }
-                          },
-                          {
-                            "value": {
-                              "scalarFunction": {
-                                "functionReference": 3,
-                                "outputType": {
-                                  "bool": {
-                                    "nullability": "NULLABILITY_NULLABLE"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "value": {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {
-                                            "field": 4
-                                          }
-                                        },
-                                        "rootReference": {}
+                                }
+                              },
+                              {
+                                "value": {
+                                  "scalarFunction": {
+                                    "functionReference": 3,
+                                    "outputType": {
+                                      "bool": {
+                                        "nullability": "NULLABILITY_NULLABLE"
                                       }
-                                    }
-                                  },
-                                  {
-                                    "value": {
-                                      "scalarFunction": {
-                                        "functionReference": 4,
-                                        "outputType": {
-                                          "decimal": {
-                                            "scale": 2,
-                                            "precision": 15,
-                                            "nullability": "NULLABILITY_NULLABLE"
+                                    },
+                                    "arguments": [
+                                      {
+                                        "value": {
+                                          "selection": {
+                                            "directReference": {
+                                              "structField": {
+                                                "field": 4
+                                              }
+                                            },
+                                            "rootReference": {}
                                           }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "value": {
-                                              "subquery": {
-                                                "scalar": {
-                                                  "input": {
-                                                    "aggregate": {
+                                        }
+                                      },
+                                      {
+                                        "value": {
+                                          "scalarFunction": {
+                                            "functionReference": 4,
+                                            "outputType": {
+                                              "decimal": {
+                                                "scale": 2,
+                                                "precision": 15,
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "subquery": {
+                                                    "scalar": {
                                                       "input": {
-                                                        "filter": {
-                                                          "input": {
-                                                            "read": {
-                                                              "common": {
-                                                                "direct": {}
-                                                              },
-                                                              "baseSchema": {
-                                                                "names": [
-                                                                  "l_orderkey",
-                                                                  "l_partkey",
-                                                                  "l_suppkey",
-                                                                  "l_linenumber",
-                                                                  "l_quantity",
-                                                                  "l_extendedprice",
-                                                                  "l_discount",
-                                                                  "l_tax",
-                                                                  "l_returnflag",
-                                                                  "l_linestatus",
-                                                                  "l_shipdate",
-                                                                  "l_commitdate",
-                                                                  "l_receiptdate",
-                                                                  "l_shipinstruct",
-                                                                  "l_shipmode",
-                                                                  "l_comment"
-                                                                ],
-                                                                "struct": {
-                                                                  "types": [
-                                                                    {
-                                                                      "i64": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "i64": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "i64": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "i64": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "decimal": {
-                                                                        "scale": 2,
-                                                                        "precision": 15,
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "date": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "date": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "date": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    {
-                                                                      "string": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    }
-                                                                  ],
-                                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                                }
-                                                              },
-                                                              "namedTable": {
-                                                                "names": [
-                                                                  "lineitem"
-                                                                ]
-                                                              }
+                                                        "project": {
+                                                          "common": {
+                                                            "emit": {
+                                                              "outputMapping": [
+                                                                1
+                                                              ]
                                                             }
                                                           },
-                                                          "condition": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 1,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 1
+                                                          "input": {
+                                                            "aggregate": {
+                                                              "input": {
+                                                                "filter": {
+                                                                  "input": {
+                                                                    "read": {
+                                                                      "common": {
+                                                                        "direct": {}
+                                                                      },
+                                                                      "baseSchema": {
+                                                                        "names": [
+                                                                          "l_orderkey",
+                                                                          "l_partkey",
+                                                                          "l_suppkey",
+                                                                          "l_linenumber",
+                                                                          "l_quantity",
+                                                                          "l_extendedprice",
+                                                                          "l_discount",
+                                                                          "l_tax",
+                                                                          "l_returnflag",
+                                                                          "l_linestatus",
+                                                                          "l_shipdate",
+                                                                          "l_commitdate",
+                                                                          "l_receiptdate",
+                                                                          "l_shipinstruct",
+                                                                          "l_shipmode",
+                                                                          "l_comment"
+                                                                        ],
+                                                                        "struct": {
+                                                                          "types": [
+                                                                            {
+                                                                              "i64": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "i64": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "i64": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "i64": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "decimal": {
+                                                                                "scale": 2,
+                                                                                "precision": 15,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "decimal": {
+                                                                                "scale": 2,
+                                                                                "precision": 15,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "decimal": {
+                                                                                "scale": 2,
+                                                                                "precision": 15,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "decimal": {
+                                                                                "scale": 2,
+                                                                                "precision": 15,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "string": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "string": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "date": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "date": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "date": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "string": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "string": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "string": {
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                              }
+                                                                            }
+                                                                          ],
+                                                                          "nullability": "NULLABILITY_REQUIRED"
                                                                         }
                                                                       },
-                                                                      "rootReference": {}
+                                                                      "namedTable": {
+                                                                        "names": [
+                                                                          "lineitem"
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "condition": {
+                                                                    "scalarFunction": {
+                                                                      "functionReference": 1,
+                                                                      "outputType": {
+                                                                        "bool": {
+                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                        }
+                                                                      },
+                                                                      "arguments": [
+                                                                        {
+                                                                          "value": {
+                                                                            "selection": {
+                                                                              "directReference": {
+                                                                                "structField": {
+                                                                                  "field": 1
+                                                                                }
+                                                                              },
+                                                                              "rootReference": {}
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        {
+                                                                          "value": {
+                                                                            "selection": {
+                                                                              "directReference": {
+                                                                                "structField": {
+                                                                                  "field": 16
+                                                                                }
+                                                                              },
+                                                                              "rootReference": {}
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      ]
                                                                     }
                                                                   }
-                                                                },
+                                                                }
+                                                              },
+                                                              "groupings": [
+                                                                {}
+                                                              ],
+                                                              "measures": [
                                                                 {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 16
+                                                                  "measure": {
+                                                                    "functionReference": 5,
+                                                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                                    "outputType": {
+                                                                      "decimal": {
+                                                                        "scale": 2,
+                                                                        "precision": 15,
+                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                      }
+                                                                    },
+                                                                    "arguments": [
+                                                                      {
+                                                                        "value": {
+                                                                          "selection": {
+                                                                            "directReference": {
+                                                                              "structField": {
+                                                                                "field": 4
+                                                                              }
+                                                                            },
+                                                                            "rootReference": {}
+                                                                          }
                                                                         }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
+                                                                      }
+                                                                    ]
                                                                   }
                                                                 }
                                                               ]
                                                             }
-                                                          }
-                                                        }
-                                                      },
-                                                      "groupings": [
-                                                        {}
-                                                      ],
-                                                      "measures": [
-                                                        {
-                                                          "measure": {
-                                                            "functionReference": 5,
-                                                            "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                            "outputType": {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                          },
+                                                          "expressions": [
+                                                            {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {}
+                                                                },
+                                                                "rootReference": {}
                                                               }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 4
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
+                                                            }
+                                                          ]
                                                         }
-                                                      ]
+                                                      }
                                                     }
                                                   }
                                                 }
-                                              }
-                                            }
-                                          },
-                                          {
-                                            "value": {
-                                              "cast": {
-                                                "type": {
-                                                  "decimal": {
-                                                    "scale": 2,
-                                                    "precision": 15,
-                                                    "nullability": "NULLABILITY_NULLABLE"
+                                              },
+                                              {
+                                                "value": {
+                                                  "cast": {
+                                                    "type": {
+                                                      "decimal": {
+                                                        "scale": 2,
+                                                        "precision": 15,
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "input": {
+                                                      "literal": {
+                                                        "fp64": 0.2
+                                                      }
+                                                    },
+                                                    "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
                                                   }
-                                                },
-                                                "input": {
-                                                  "literal": {
-                                                    "fp64": 0.2
-                                                  }
-                                                },
-                                                "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                }
                                               }
-                                            }
+                                            ]
                                           }
-                                        ]
+                                        }
                                       }
-                                    }
+                                    ]
                                   }
-                                ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "groupings": [
+                      {}
+                    ],
+                    "measures": [
+                      {
+                        "measure": {
+                          "functionReference": 6,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
+                                }
                               }
                             }
-                          }
-                        ]
+                          ]
+                        }
                       }
-                    }
+                    ]
                   }
                 },
-                "groupings": [
-                  {}
-                ],
-                "measures": [
+                "expressions": [
                   {
-                    "measure": {
-                      "functionReference": 6,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
-                        }
-                      ]
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
@@ -40,123 +40,251 @@
             "input": {
               "sort": {
                 "input": {
-                  "aggregate": {
+                  "project": {
+                    "common": {
+                      "emit": {
+                        "outputMapping": [
+                          6,
+                          7,
+                          8,
+                          9,
+                          10,
+                          11
+                        ]
+                      }
+                    },
                     "input": {
-                      "filter": {
+                      "aggregate": {
                         "input": {
-                          "project": {
-                            "common": {
-                              "emit": {
-                                "outputMapping": [
-                                  33,
-                                  34,
-                                  35,
-                                  36,
-                                  37,
-                                  38,
-                                  39,
-                                  40,
-                                  41,
-                                  42,
-                                  43,
-                                  44,
-                                  45,
-                                  46,
-                                  47,
-                                  48,
-                                  49,
-                                  50,
-                                  51,
-                                  52,
-                                  53,
-                                  54,
-                                  55,
-                                  56,
-                                  57,
-                                  58,
-                                  59,
-                                  60,
-                                  61,
-                                  62,
-                                  63,
-                                  64,
-                                  65
-                                ]
-                              }
-                            },
+                          "filter": {
                             "input": {
-                              "join": {
-                                "left": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      33,
+                                      34,
+                                      35,
+                                      36,
+                                      37,
+                                      38,
+                                      39,
+                                      40,
+                                      41,
+                                      42,
+                                      43,
+                                      44,
+                                      45,
+                                      46,
+                                      47,
+                                      48,
+                                      49,
+                                      50,
+                                      51,
+                                      52,
+                                      53,
+                                      54,
+                                      55,
+                                      56,
+                                      57,
+                                      58,
+                                      59,
+                                      60,
+                                      61,
+                                      62,
+                                      63,
+                                      64,
+                                      65
+                                    ]
+                                  }
+                                },
+                                "input": {
                                   "join": {
                                     "left": {
-                                      "read": {
-                                        "common": {
-                                          "direct": {}
-                                        },
-                                        "baseSchema": {
-                                          "names": [
-                                            "c_custkey",
-                                            "c_name",
-                                            "c_address",
-                                            "c_nationkey",
-                                            "c_phone",
-                                            "c_acctbal",
-                                            "c_mktsegment",
-                                            "c_comment"
-                                          ],
-                                          "struct": {
-                                            "types": [
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
+                                      "join": {
+                                        "left": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "c_custkey",
+                                                "c_name",
+                                                "c_address",
+                                                "c_nationkey",
+                                                "c_phone",
+                                                "c_acctbal",
+                                                "c_mktsegment",
+                                                "c_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
                                               }
-                                            ],
-                                            "nullability": "NULLABILITY_REQUIRED"
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "customer"
+                                              ]
+                                            }
                                           }
                                         },
-                                        "namedTable": {
-                                          "names": [
-                                            "customer"
-                                          ]
-                                        }
+                                        "right": {
+                                          "read": {
+                                            "common": {
+                                              "direct": {}
+                                            },
+                                            "baseSchema": {
+                                              "names": [
+                                                "o_orderkey",
+                                                "o_custkey",
+                                                "o_orderstatus",
+                                                "o_totalprice",
+                                                "o_orderdate",
+                                                "o_orderpriority",
+                                                "o_clerk",
+                                                "o_shippriority",
+                                                "o_comment"
+                                              ],
+                                              "struct": {
+                                                "types": [
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "date": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "string": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  }
+                                                ],
+                                                "nullability": "NULLABILITY_REQUIRED"
+                                              }
+                                            },
+                                            "namedTable": {
+                                              "names": [
+                                                "orders"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "expression": {
+                                          "scalarFunction": {
+                                            "functionReference": 1,
+                                            "outputType": {
+                                              "bool": {
+                                                "nullability": "NULLABILITY_NULLABLE"
+                                              }
+                                            },
+                                            "arguments": [
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {}
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              },
+                                              {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 9
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "JOIN_TYPE_INNER"
                                       }
                                     },
                                     "right": {
@@ -166,63 +294,111 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "o_orderkey",
-                                            "o_custkey",
-                                            "o_orderstatus",
-                                            "o_totalprice",
-                                            "o_orderdate",
-                                            "o_orderpriority",
-                                            "o_clerk",
-                                            "o_shippriority",
-                                            "o_comment"
+                                            "l_orderkey",
+                                            "l_partkey",
+                                            "l_suppkey",
+                                            "l_linenumber",
+                                            "l_quantity",
+                                            "l_extendedprice",
+                                            "l_discount",
+                                            "l_tax",
+                                            "l_returnflag",
+                                            "l_linestatus",
+                                            "l_shipdate",
+                                            "l_commitdate",
+                                            "l_receiptdate",
+                                            "l_shipinstruct",
+                                            "l_shipmode",
+                                            "l_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "i64": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "decimal": {
                                                   "scale": 2,
                                                   "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "string": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "date": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              {
+                                                "date": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               },
                                               {
                                                 "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
+                                                  "nullability": "NULLABILITY_NULLABLE"
                                                 }
                                               }
                                             ],
@@ -231,7 +407,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "orders"
+                                            "lineitem"
                                           ]
                                         }
                                       }
@@ -249,7 +425,9 @@
                                             "value": {
                                               "selection": {
                                                 "directReference": {
-                                                  "structField": {}
+                                                  "structField": {
+                                                    "field": 8
+                                                  }
                                                 },
                                                 "rootReference": {}
                                               }
@@ -260,7 +438,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 9
+                                                    "field": 17
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -273,179 +451,621 @@
                                     "type": "JOIN_TYPE_INNER"
                                   }
                                 },
-                                "right": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "l_orderkey",
-                                        "l_partkey",
-                                        "l_suppkey",
-                                        "l_linenumber",
-                                        "l_quantity",
-                                        "l_extendedprice",
-                                        "l_discount",
-                                        "l_tax",
-                                        "l_returnflag",
-                                        "l_linestatus",
-                                        "l_shipdate",
-                                        "l_commitdate",
-                                        "l_receiptdate",
-                                        "l_shipinstruct",
-                                        "l_shipmode",
-                                        "l_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "i64": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "date": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "lineitem"
-                                      ]
+                                "expressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {}
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 2
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 3
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 6
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 7
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 8
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 9
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 10
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 11
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 12
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 13
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 14
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 15
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 16
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 17
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 18
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 19
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 20
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 21
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 22
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 23
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 24
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 25
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 26
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 27
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 28
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 29
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 30
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 31
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 32
+                                        }
+                                      },
+                                      "rootReference": {}
                                     }
                                   }
-                                },
-                                "expression": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
+                                ]
+                              }
+                            },
+                            "condition": {
+                              "subquery": {
+                                "inPredicate": {
+                                  "needles": [
+                                    {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 8
+                                          }
+                                        },
+                                        "rootReference": {}
                                       }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 8
-                                              }
-                                            },
-                                            "rootReference": {}
+                                    }
+                                  ],
+                                  "haystack": {
+                                    "project": {
+                                      "common": {
+                                        "emit": {
+                                          "outputMapping": [
+                                            2
+                                          ]
+                                        }
+                                      },
+                                      "input": {
+                                        "filter": {
+                                          "input": {
+                                            "project": {
+                                              "common": {
+                                                "emit": {
+                                                  "outputMapping": [
+                                                    2,
+                                                    3
+                                                  ]
+                                                }
+                                              },
+                                              "input": {
+                                                "aggregate": {
+                                                  "input": {
+                                                    "read": {
+                                                      "common": {
+                                                        "direct": {}
+                                                      },
+                                                      "baseSchema": {
+                                                        "names": [
+                                                          "l_orderkey",
+                                                          "l_partkey",
+                                                          "l_suppkey",
+                                                          "l_linenumber",
+                                                          "l_quantity",
+                                                          "l_extendedprice",
+                                                          "l_discount",
+                                                          "l_tax",
+                                                          "l_returnflag",
+                                                          "l_linestatus",
+                                                          "l_shipdate",
+                                                          "l_commitdate",
+                                                          "l_receiptdate",
+                                                          "l_shipinstruct",
+                                                          "l_shipmode",
+                                                          "l_comment"
+                                                        ],
+                                                        "struct": {
+                                                          "types": [
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "i64": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "decimal": {
+                                                                "scale": 2,
+                                                                "precision": 15,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "date": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "date": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "date": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            {
+                                                              "string": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            }
+                                                          ],
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      "namedTable": {
+                                                        "names": [
+                                                          "lineitem"
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  "groupings": [
+                                                    {
+                                                      "groupingExpressions": [
+                                                        {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {}
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "measures": [
+                                                    {
+                                                      "measure": {
+                                                        "functionReference": 2,
+                                                        "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                        "outputType": {
+                                                          "decimal": {
+                                                            "scale": 2,
+                                                            "precision": 38,
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 4
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "expressions": [
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {}
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                },
+                                                {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 1
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "condition": {
+                                            "scalarFunction": {
+                                              "functionReference": 3,
+                                              "outputType": {
+                                                "bool": {
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "value": {
+                                                    "selection": {
+                                                      "directReference": {
+                                                        "structField": {
+                                                          "field": 1
+                                                        }
+                                                      },
+                                                      "rootReference": {}
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "value": {
+                                                    "literal": {
+                                                      "i16": 300
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
                                           }
                                         }
                                       },
-                                      {
-                                        "value": {
+                                      "expressions": [
+                                        {
                                           "selection": {
                                             "directReference": {
-                                              "structField": {
-                                                "field": 17
-                                              }
+                                              "structField": {}
                                             },
                                             "rootReference": {}
                                           }
                                         }
-                                      }
-                                    ]
+                                      ]
+                                    }
                                   }
-                                },
-                                "type": "JOIN_TYPE_INNER"
-                              }
-                            },
-                            "expressions": [
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {}
-                                  },
-                                  "rootReference": {}
                                 }
-                              },
+                              }
+                            }
+                          }
+                        },
+                        "groupings": [
+                          {
+                            "groupingExpressions": [
                               {
                                 "selection": {
                                   "directReference": {
@@ -459,59 +1079,7 @@
                               {
                                 "selection": {
                                   "directReference": {
-                                    "structField": {
-                                      "field": 2
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 3
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 4
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 5
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 6
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 7
-                                    }
+                                    "structField": {}
                                   },
                                   "rootReference": {}
                                 }
@@ -521,36 +1089,6 @@
                                   "directReference": {
                                     "structField": {
                                       "field": 8
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 9
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 10
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 11
                                     }
                                   },
                                   "rootReference": {}
@@ -570,197 +1108,7 @@
                                 "selection": {
                                   "directReference": {
                                     "structField": {
-                                      "field": 13
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 14
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 15
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 16
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 17
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 18
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 19
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 20
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 21
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 22
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 23
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 24
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 25
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 26
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 27
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 28
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 29
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 30
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 31
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 32
+                                      "field": 11
                                     }
                                   },
                                   "rootReference": {}
@@ -768,335 +1116,95 @@
                               }
                             ]
                           }
-                        },
-                        "condition": {
-                          "subquery": {
-                            "inPredicate": {
-                              "needles": [
-                                {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 8
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
+                        ],
+                        "measures": [
+                          {
+                            "measure": {
+                              "functionReference": 2,
+                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 38,
+                                  "nullability": "NULLABILITY_NULLABLE"
                                 }
-                              ],
-                              "haystack": {
-                                "project": {
-                                  "common": {
-                                    "emit": {
-                                      "outputMapping": [
-                                        2
-                                      ]
-                                    }
-                                  },
-                                  "input": {
-                                    "filter": {
-                                      "input": {
-                                        "aggregate": {
-                                          "input": {
-                                            "read": {
-                                              "common": {
-                                                "direct": {}
-                                              },
-                                              "baseSchema": {
-                                                "names": [
-                                                  "l_orderkey",
-                                                  "l_partkey",
-                                                  "l_suppkey",
-                                                  "l_linenumber",
-                                                  "l_quantity",
-                                                  "l_extendedprice",
-                                                  "l_discount",
-                                                  "l_tax",
-                                                  "l_returnflag",
-                                                  "l_linestatus",
-                                                  "l_shipdate",
-                                                  "l_commitdate",
-                                                  "l_receiptdate",
-                                                  "l_shipinstruct",
-                                                  "l_shipmode",
-                                                  "l_comment"
-                                                ],
-                                                "struct": {
-                                                  "types": [
-                                                    {
-                                                      "i64": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "i64": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "i64": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "i64": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "decimal": {
-                                                        "scale": 2,
-                                                        "precision": 15,
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "decimal": {
-                                                        "scale": 2,
-                                                        "precision": 15,
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "decimal": {
-                                                        "scale": 2,
-                                                        "precision": 15,
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "decimal": {
-                                                        "scale": 2,
-                                                        "precision": 15,
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "date": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "date": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "date": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    {
-                                                      "string": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    }
-                                                  ],
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              "namedTable": {
-                                                "names": [
-                                                  "lineitem"
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          "groupings": [
-                                            {
-                                              "groupingExpressions": [
-                                                {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {}
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "measures": [
-                                            {
-                                              "measure": {
-                                                "functionReference": 2,
-                                                "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                "outputType": {
-                                                  "decimal": {
-                                                    "scale": 2,
-                                                    "precision": 38,
-                                                    "nullability": "NULLABILITY_NULLABLE"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 4
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          ]
+                              },
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 21
                                         }
                                       },
-                                      "condition": {
-                                        "scalarFunction": {
-                                          "functionReference": 3,
-                                          "outputType": {
-                                            "bool": {
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "value": {
-                                                "selection": {
-                                                  "directReference": {
-                                                    "structField": {
-                                                      "field": 1
-                                                    }
-                                                  },
-                                                  "rootReference": {}
-                                                }
-                                              }
-                                            },
-                                            {
-                                              "value": {
-                                                "literal": {
-                                                  "i16": 300
-                                                }
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      }
+                                      "rootReference": {}
                                     }
-                                  },
-                                  "expressions": [
-                                    {
-                                      "selection": {
-                                        "directReference": {
-                                          "structField": {}
-                                        },
-                                        "rootReference": {}
-                                      }
-                                    }
-                                  ]
+                                  }
                                 }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "groupings": [
-                      {
-                        "groupingExpressions": [
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {}
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 8
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 12
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          },
-                          {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 11
-                                }
-                              },
-                              "rootReference": {}
+                              ]
                             }
                           }
                         ]
                       }
-                    ],
-                    "measures": [
+                    },
+                    "expressions": [
                       {
-                        "measure": {
-                          "functionReference": 2,
-                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 38,
-                              "nullability": "NULLABILITY_NULLABLE"
+                        "selection": {
+                          "directReference": {
+                            "structField": {}
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
                             }
                           },
-                          "arguments": [
-                            {
-                              "value": {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 21
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              }
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 2
                             }
-                          ]
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 3
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 4
+                            }
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 5
+                            }
+                          },
+                          "rootReference": {}
                         }
                       }
                     ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
@@ -82,1623 +82,1644 @@
     {
       "root": {
         "input": {
-          "aggregate": {
+          "project": {
+            "common": {
+              "emit": {
+                "outputMapping": [
+                  1
+                ]
+              }
+            },
             "input": {
-              "filter": {
+              "aggregate": {
                 "input": {
-                  "project": {
-                    "common": {
-                      "emit": {
-                        "outputMapping": [
-                          25,
-                          26,
-                          27,
-                          28,
-                          29,
-                          30,
-                          31,
-                          32,
-                          33,
-                          34,
-                          35,
-                          36,
-                          37,
-                          38,
-                          39,
-                          40,
-                          41,
-                          42,
-                          43,
-                          44,
-                          45,
-                          46,
-                          47,
-                          48,
-                          49
+                  "filter": {
+                    "input": {
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              25,
+                              26,
+                              27,
+                              28,
+                              29,
+                              30,
+                              31,
+                              32,
+                              33,
+                              34,
+                              35,
+                              36,
+                              37,
+                              38,
+                              39,
+                              40,
+                              41,
+                              42,
+                              43,
+                              44,
+                              45,
+                              46,
+                              47,
+                              48,
+                              49
+                            ]
+                          }
+                        },
+                        "input": {
+                          "join": {
+                            "left": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "l_orderkey",
+                                    "l_partkey",
+                                    "l_suppkey",
+                                    "l_linenumber",
+                                    "l_quantity",
+                                    "l_extendedprice",
+                                    "l_discount",
+                                    "l_tax",
+                                    "l_returnflag",
+                                    "l_linestatus",
+                                    "l_shipdate",
+                                    "l_commitdate",
+                                    "l_receiptdate",
+                                    "l_shipinstruct",
+                                    "l_shipmode",
+                                    "l_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "i64": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "date": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "lineitem"
+                                  ]
+                                }
+                              }
+                            },
+                            "right": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "p_partkey",
+                                    "p_name",
+                                    "p_mfgr",
+                                    "p_brand",
+                                    "p_type",
+                                    "p_size",
+                                    "p_container",
+                                    "p_retailprice",
+                                    "p_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "part"
+                                  ]
+                                }
+                              }
+                            },
+                            "expression": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 16
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "selection": {
+                                        "directReference": {
+                                          "structField": {
+                                            "field": 1
+                                          }
+                                        },
+                                        "rootReference": {}
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "JOIN_TYPE_INNER"
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 1
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 2
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 3
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 4
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 6
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 7
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 8
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 9
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 10
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 11
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 12
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 13
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 14
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 15
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 16
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 17
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 18
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 19
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 20
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 21
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 22
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 23
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 24
+                                }
+                              },
+                              "rootReference": {}
+                            }
+                          }
                         ]
                       }
                     },
-                    "input": {
-                      "join": {
-                        "left": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "l_orderkey",
-                                "l_partkey",
-                                "l_suppkey",
-                                "l_linenumber",
-                                "l_quantity",
-                                "l_extendedprice",
-                                "l_discount",
-                                "l_tax",
-                                "l_returnflag",
-                                "l_linestatus",
-                                "l_shipdate",
-                                "l_commitdate",
-                                "l_receiptdate",
-                                "l_shipinstruct",
-                                "l_shipmode",
-                                "l_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "i64": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "date": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "lineitem"
-                              ]
-                            }
+                    "condition": {
+                      "scalarFunction": {
+                        "functionReference": 2,
+                        "outputType": {
+                          "bool": {
+                            "nullability": "NULLABILITY_NULLABLE"
                           }
                         },
-                        "right": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "p_partkey",
-                                "p_name",
-                                "p_mfgr",
-                                "p_brand",
-                                "p_type",
-                                "p_size",
-                                "p_container",
-                                "p_retailprice",
-                                "p_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
+                        "arguments": [
+                          {
+                            "value": {
+                              "scalarFunction": {
+                                "functionReference": 2,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
                                   }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "part"
-                              ]
-                            }
-                          }
-                        },
-                        "expression": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 16
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "selection": {
-                                    "directReference": {
-                                      "structField": {
-                                        "field": 1
-                                      }
-                                    },
-                                    "rootReference": {}
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "type": "JOIN_TYPE_INNER"
-                      }
-                    },
-                    "expressions": [
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {}
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 1
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 2
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 3
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 4
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 5
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 6
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 7
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 8
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 9
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 10
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 11
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 12
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 13
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 14
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 15
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 16
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 17
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 18
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 19
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 20
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 21
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 22
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 23
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 24
-                            }
-                          },
-                          "rootReference": {}
-                        }
-                      }
-                    ]
-                  }
-                },
-                "condition": {
-                  "scalarFunction": {
-                    "functionReference": 2,
-                    "outputType": {
-                      "bool": {
-                        "nullability": "NULLABILITY_NULLABLE"
-                      }
-                    },
-                    "arguments": [
-                      {
-                        "value": {
-                          "scalarFunction": {
-                            "functionReference": 2,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 3,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 3,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 3,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "scalarFunction": {
-                                                                    "functionReference": 3,
-                                                                    "outputType": {
-                                                                      "bool": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    "arguments": [
-                                                                      {
-                                                                        "value": {
-                                                                          "scalarFunction": {
-                                                                            "functionReference": 3,
-                                                                            "outputType": {
-                                                                              "bool": {
-                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                              }
-                                                                            },
-                                                                            "arguments": [
-                                                                              {
-                                                                                "value": {
-                                                                                  "scalarFunction": {
-                                                                                    "functionReference": 1,
-                                                                                    "outputType": {
-                                                                                      "bool": {
-                                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 3,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 3,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 3,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 3,
+                                                                        "outputType": {
+                                                                          "bool": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "scalarFunction": {
+                                                                                "functionReference": 3,
+                                                                                "outputType": {
+                                                                                  "bool": {
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                  }
+                                                                                },
+                                                                                "arguments": [
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "scalarFunction": {
+                                                                                        "functionReference": 1,
+                                                                                        "outputType": {
+                                                                                          "bool": {
+                                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                        },
+                                                                                        "arguments": [
+                                                                                          {
+                                                                                            "value": {
+                                                                                              "selection": {
+                                                                                                "directReference": {
+                                                                                                  "structField": {
+                                                                                                    "field": 19
+                                                                                                  }
+                                                                                                },
+                                                                                                "rootReference": {}
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "value": {
+                                                                                              "literal": {
+                                                                                                "string": "Brand#12"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        ]
                                                                                       }
-                                                                                    },
-                                                                                    "arguments": [
-                                                                                      {
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "singularOrList": {
                                                                                         "value": {
                                                                                           "selection": {
                                                                                             "directReference": {
                                                                                               "structField": {
-                                                                                                "field": 19
+                                                                                                "field": 22
                                                                                               }
                                                                                             },
                                                                                             "rootReference": {}
                                                                                           }
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "value": {
-                                                                                          "literal": {
-                                                                                            "string": "Brand#12"
+                                                                                        },
+                                                                                        "options": [
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "SM CASE"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "SM BOX"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "SM PACK"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "SM PKG"
+                                                                                            }
                                                                                           }
-                                                                                        }
+                                                                                        ]
                                                                                       }
-                                                                                    ]
+                                                                                    }
                                                                                   }
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "value": {
-                                                                                  "singularOrList": {
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "scalarFunction": {
+                                                                                "functionReference": 4,
+                                                                                "outputType": {
+                                                                                  "bool": {
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                  }
+                                                                                },
+                                                                                "arguments": [
+                                                                                  {
                                                                                     "value": {
                                                                                       "selection": {
                                                                                         "directReference": {
                                                                                           "structField": {
-                                                                                            "field": 22
+                                                                                            "field": 4
                                                                                           }
                                                                                         },
                                                                                         "rootReference": {}
                                                                                       }
-                                                                                    },
-                                                                                    "options": [
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "SM CASE"
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "SM BOX"
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "SM PACK"
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "SM PKG"
-                                                                                        }
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                }
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "value": {
-                                                                          "scalarFunction": {
-                                                                            "functionReference": 4,
-                                                                            "outputType": {
-                                                                              "bool": {
-                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                              }
-                                                                            },
-                                                                            "arguments": [
-                                                                              {
-                                                                                "value": {
-                                                                                  "selection": {
-                                                                                    "directReference": {
-                                                                                      "structField": {
-                                                                                        "field": 4
-                                                                                      }
-                                                                                    },
-                                                                                    "rootReference": {}
-                                                                                  }
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "value": {
-                                                                                  "literal": {
-                                                                                    "i8": 1
-                                                                                  }
-                                                                                }
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "scalarFunction": {
-                                                                    "functionReference": 5,
-                                                                    "outputType": {
-                                                                      "bool": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    "arguments": [
-                                                                      {
-                                                                        "value": {
-                                                                          "selection": {
-                                                                            "directReference": {
-                                                                              "structField": {
-                                                                                "field": 4
-                                                                              }
-                                                                            },
-                                                                            "rootReference": {}
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "value": {
-                                                                          "literal": {
-                                                                            "i8": 11
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 6,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 21
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "literal": {
-                                                                    "i8": 1
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "literal": {
-                                                                    "i8": 5
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "singularOrList": {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 14
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    "options": [
-                                                      {
-                                                        "literal": {
-                                                          "string": "AIR"
-                                                        }
-                                                      },
-                                                      {
-                                                        "literal": {
-                                                          "string": "AIR REG"
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 1,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 13
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "DELIVER IN PERSON"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 3,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 3,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 3,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "scalarFunction": {
-                                                                    "functionReference": 3,
-                                                                    "outputType": {
-                                                                      "bool": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    "arguments": [
-                                                                      {
-                                                                        "value": {
-                                                                          "scalarFunction": {
-                                                                            "functionReference": 3,
-                                                                            "outputType": {
-                                                                              "bool": {
-                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                              }
-                                                                            },
-                                                                            "arguments": [
-                                                                              {
-                                                                                "value": {
-                                                                                  "scalarFunction": {
-                                                                                    "functionReference": 1,
-                                                                                    "outputType": {
-                                                                                      "bool": {
-                                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                                      }
-                                                                                    },
-                                                                                    "arguments": [
-                                                                                      {
-                                                                                        "value": {
-                                                                                          "selection": {
-                                                                                            "directReference": {
-                                                                                              "structField": {
-                                                                                                "field": 19
-                                                                                              }
-                                                                                            },
-                                                                                            "rootReference": {}
-                                                                                          }
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "value": {
-                                                                                          "literal": {
-                                                                                            "string": "Brand#23"
-                                                                                          }
-                                                                                        }
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "value": {
-                                                                                  "singularOrList": {
+                                                                                    }
+                                                                                  },
+                                                                                  {
                                                                                     "value": {
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                            "field": 22
-                                                                                          }
-                                                                                        },
-                                                                                        "rootReference": {}
+                                                                                      "literal": {
+                                                                                        "i8": 1
                                                                                       }
-                                                                                    },
-                                                                                    "options": [
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "MED BAG"
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "MED BOX"
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "MED PKG"
-                                                                                        }
-                                                                                      },
-                                                                                      {
-                                                                                        "literal": {
-                                                                                          "string": "MED PACK"
-                                                                                        }
-                                                                                      }
-                                                                                    ]
+                                                                                    }
                                                                                   }
-                                                                                }
+                                                                                ]
                                                                               }
-                                                                            ]
+                                                                            }
                                                                           }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "value": {
-                                                                          "scalarFunction": {
-                                                                            "functionReference": 4,
-                                                                            "outputType": {
-                                                                              "bool": {
-                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                              }
-                                                                            },
-                                                                            "arguments": [
-                                                                              {
-                                                                                "value": {
-                                                                                  "selection": {
-                                                                                    "directReference": {
-                                                                                      "structField": {
-                                                                                        "field": 4
-                                                                                      }
-                                                                                    },
-                                                                                    "rootReference": {}
-                                                                                  }
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "value": {
-                                                                                  "literal": {
-                                                                                    "i8": 10
-                                                                                  }
-                                                                                }
-                                                                              }
-                                                                            ]
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 5,
+                                                                        "outputType": {
+                                                                          "bool": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
                                                                           }
-                                                                        }
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "scalarFunction": {
-                                                                    "functionReference": 5,
-                                                                    "outputType": {
-                                                                      "bool": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    "arguments": [
-                                                                      {
-                                                                        "value": {
-                                                                          "selection": {
-                                                                            "directReference": {
-                                                                              "structField": {
-                                                                                "field": 4
-                                                                              }
-                                                                            },
-                                                                            "rootReference": {}
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "value": {
-                                                                          "literal": {
-                                                                            "i8": 20
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 6,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 21
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "literal": {
-                                                                    "i8": 1
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "literal": {
-                                                                    "i8": 10
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "singularOrList": {
-                                                    "value": {
-                                                      "selection": {
-                                                        "directReference": {
-                                                          "structField": {
-                                                            "field": 14
-                                                          }
-                                                        },
-                                                        "rootReference": {}
-                                                      }
-                                                    },
-                                                    "options": [
-                                                      {
-                                                        "literal": {
-                                                          "string": "AIR"
-                                                        }
-                                                      },
-                                                      {
-                                                        "literal": {
-                                                          "string": "AIR REG"
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 1,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 13
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "literal": {
-                                                    "string": "DELIVER IN PERSON"
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      },
-                      {
-                        "value": {
-                          "scalarFunction": {
-                            "functionReference": 3,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 3,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 3,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 3,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "scalarFunction": {
-                                                                    "functionReference": 3,
-                                                                    "outputType": {
-                                                                      "bool": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    "arguments": [
-                                                                      {
-                                                                        "value": {
-                                                                          "scalarFunction": {
-                                                                            "functionReference": 1,
-                                                                            "outputType": {
-                                                                              "bool": {
-                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                              }
-                                                                            },
-                                                                            "arguments": [
-                                                                              {
-                                                                                "value": {
-                                                                                  "selection": {
-                                                                                    "directReference": {
-                                                                                      "structField": {
-                                                                                        "field": 19
-                                                                                      }
-                                                                                    },
-                                                                                    "rootReference": {}
-                                                                                  }
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "value": {
-                                                                                  "literal": {
-                                                                                    "string": "Brand#34"
-                                                                                  }
-                                                                                }
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "value": {
-                                                                          "singularOrList": {
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
                                                                             "value": {
                                                                               "selection": {
                                                                                 "directReference": {
                                                                                   "structField": {
-                                                                                    "field": 22
+                                                                                    "field": 4
                                                                                   }
                                                                                 },
                                                                                 "rootReference": {}
                                                                               }
-                                                                            },
-                                                                            "options": [
-                                                                              {
-                                                                                "literal": {
-                                                                                  "string": "LG CASE"
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "literal": {
-                                                                                  "string": "LG BOX"
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "literal": {
-                                                                                  "string": "LG PACK"
-                                                                                }
-                                                                              },
-                                                                              {
-                                                                                "literal": {
-                                                                                  "string": "LG PKG"
-                                                                                }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "literal": {
+                                                                                "i8": 11
                                                                               }
-                                                                            ]
+                                                                            }
                                                                           }
-                                                                        }
+                                                                        ]
                                                                       }
-                                                                    ]
+                                                                    }
                                                                   }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "scalarFunction": {
-                                                                    "functionReference": 4,
-                                                                    "outputType": {
-                                                                      "bool": {
-                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                      }
-                                                                    },
-                                                                    "arguments": [
-                                                                      {
-                                                                        "value": {
-                                                                          "selection": {
-                                                                            "directReference": {
-                                                                              "structField": {
-                                                                                "field": 4
-                                                                              }
-                                                                            },
-                                                                            "rootReference": {}
-                                                                          }
-                                                                        }
-                                                                      },
-                                                                      {
-                                                                        "value": {
-                                                                          "literal": {
-                                                                            "i8": 20
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                }
+                                                                ]
                                                               }
-                                                            ]
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 6,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 21
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "literal": {
+                                                                        "i8": 1
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "literal": {
+                                                                        "i8": 5
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
                                                           }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 5,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 4
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "literal": {
-                                                                    "i8": 30
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
+                                                        ]
                                                       }
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 6,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "singularOrList": {
                                                         "value": {
                                                           "selection": {
                                                             "directReference": {
                                                               "structField": {
-                                                                "field": 21
+                                                                "field": 14
                                                               }
                                                             },
                                                             "rootReference": {}
                                                           }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "literal": {
-                                                            "i8": 1
+                                                        },
+                                                        "options": [
+                                                          {
+                                                            "literal": {
+                                                              "string": "AIR"
+                                                            }
+                                                          },
+                                                          {
+                                                            "literal": {
+                                                              "string": "AIR REG"
+                                                            }
                                                           }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "literal": {
-                                                            "i8": 15
-                                                          }
-                                                        }
+                                                        ]
                                                       }
-                                                    ]
+                                                    }
                                                   }
-                                                }
+                                                ]
                                               }
-                                            ]
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 13
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "DELIVER IN PERSON"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
                                           }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "singularOrList": {
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 3,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 3,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 3,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 3,
+                                                                        "outputType": {
+                                                                          "bool": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "scalarFunction": {
+                                                                                "functionReference": 3,
+                                                                                "outputType": {
+                                                                                  "bool": {
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                  }
+                                                                                },
+                                                                                "arguments": [
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "scalarFunction": {
+                                                                                        "functionReference": 1,
+                                                                                        "outputType": {
+                                                                                          "bool": {
+                                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                        },
+                                                                                        "arguments": [
+                                                                                          {
+                                                                                            "value": {
+                                                                                              "selection": {
+                                                                                                "directReference": {
+                                                                                                  "structField": {
+                                                                                                    "field": 19
+                                                                                                  }
+                                                                                                },
+                                                                                                "rootReference": {}
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "value": {
+                                                                                              "literal": {
+                                                                                                "string": "Brand#23"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "singularOrList": {
+                                                                                        "value": {
+                                                                                          "selection": {
+                                                                                            "directReference": {
+                                                                                              "structField": {
+                                                                                                "field": 22
+                                                                                              }
+                                                                                            },
+                                                                                            "rootReference": {}
+                                                                                          }
+                                                                                        },
+                                                                                        "options": [
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "MED BAG"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "MED BOX"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "MED PKG"
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "literal": {
+                                                                                              "string": "MED PACK"
+                                                                                            }
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "scalarFunction": {
+                                                                                "functionReference": 4,
+                                                                                "outputType": {
+                                                                                  "bool": {
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                  }
+                                                                                },
+                                                                                "arguments": [
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "selection": {
+                                                                                        "directReference": {
+                                                                                          "structField": {
+                                                                                            "field": 4
+                                                                                          }
+                                                                                        },
+                                                                                        "rootReference": {}
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "literal": {
+                                                                                        "i8": 10
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 5,
+                                                                        "outputType": {
+                                                                          "bool": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "selection": {
+                                                                                "directReference": {
+                                                                                  "structField": {
+                                                                                    "field": 4
+                                                                                  }
+                                                                                },
+                                                                                "rootReference": {}
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "literal": {
+                                                                                "i8": 20
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 6,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 21
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "literal": {
+                                                                        "i8": 1
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "literal": {
+                                                                        "i8": 10
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "singularOrList": {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 14
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        },
+                                                        "options": [
+                                                          {
+                                                            "literal": {
+                                                              "string": "AIR"
+                                                            }
+                                                          },
+                                                          {
+                                                            "literal": {
+                                                              "string": "AIR REG"
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 13
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "literal": {
+                                                        "string": "DELIVER IN PERSON"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "value": {
+                              "scalarFunction": {
+                                "functionReference": 3,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 3,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 3,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 3,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 3,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 3,
+                                                                        "outputType": {
+                                                                          "bool": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "scalarFunction": {
+                                                                                "functionReference": 1,
+                                                                                "outputType": {
+                                                                                  "bool": {
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                  }
+                                                                                },
+                                                                                "arguments": [
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "selection": {
+                                                                                        "directReference": {
+                                                                                          "structField": {
+                                                                                            "field": 19
+                                                                                          }
+                                                                                        },
+                                                                                        "rootReference": {}
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "value": {
+                                                                                      "literal": {
+                                                                                        "string": "Brand#34"
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "singularOrList": {
+                                                                                "value": {
+                                                                                  "selection": {
+                                                                                    "directReference": {
+                                                                                      "structField": {
+                                                                                        "field": 22
+                                                                                      }
+                                                                                    },
+                                                                                    "rootReference": {}
+                                                                                  }
+                                                                                },
+                                                                                "options": [
+                                                                                  {
+                                                                                    "literal": {
+                                                                                      "string": "LG CASE"
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "literal": {
+                                                                                      "string": "LG BOX"
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "literal": {
+                                                                                      "string": "LG PACK"
+                                                                                    }
+                                                                                  },
+                                                                                  {
+                                                                                    "literal": {
+                                                                                      "string": "LG PKG"
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "scalarFunction": {
+                                                                        "functionReference": 4,
+                                                                        "outputType": {
+                                                                          "bool": {
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "selection": {
+                                                                                "directReference": {
+                                                                                  "structField": {
+                                                                                    "field": 4
+                                                                                  }
+                                                                                },
+                                                                                "rootReference": {}
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          {
+                                                                            "value": {
+                                                                              "literal": {
+                                                                                "i8": 20
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 5,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 4
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "literal": {
+                                                                        "i8": 30
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 6,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 21
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "literal": {
+                                                                "i8": 1
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "literal": {
+                                                                "i8": 15
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "singularOrList": {
+                                                "value": {
+                                                  "selection": {
+                                                    "directReference": {
+                                                      "structField": {
+                                                        "field": 14
+                                                      }
+                                                    },
+                                                    "rootReference": {}
+                                                  }
+                                                },
+                                                "options": [
+                                                  {
+                                                    "literal": {
+                                                      "string": "AIR"
+                                                    }
+                                                  },
+                                                  {
+                                                    "literal": {
+                                                      "string": "AIR REG"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
                                             "value": {
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 14
+                                                    "field": 13
                                                   }
                                                 },
                                                 "rootReference": {}
                                               }
-                                            },
-                                            "options": [
-                                              {
-                                                "literal": {
-                                                  "string": "AIR"
-                                                }
-                                              },
-                                              {
-                                                "literal": {
-                                                  "string": "AIR REG"
-                                                }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "literal": {
+                                                "string": "DELIVER IN PERSON"
                                               }
-                                            ]
+                                            }
                                           }
-                                        }
+                                        ]
                                       }
-                                    ]
+                                    }
                                   }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "groupings": [
+                  {}
+                ],
+                "measures": [
+                  {
+                    "measure": {
+                      "functionReference": 7,
+                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                      "outputType": {
+                        "decimal": {
+                          "scale": 2,
+                          "precision": 38,
+                          "nullability": "NULLABILITY_NULLABLE"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "value": {
+                            "scalarFunction": {
+                              "functionReference": 8,
+                              "outputType": {
+                                "decimal": {
+                                  "scale": 2,
+                                  "precision": 15,
+                                  "nullability": "NULLABILITY_NULLABLE"
                                 }
                               },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 13
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 5
                                         }
                                       },
-                                      {
-                                        "value": {
-                                          "literal": {
-                                            "string": "DELIVER IN PERSON"
+                                      "rootReference": {}
+                                    }
+                                  }
+                                },
+                                {
+                                  "value": {
+                                    "scalarFunction": {
+                                      "functionReference": 9,
+                                      "outputType": {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "value": {
+                                            "cast": {
+                                              "type": {
+                                                "decimal": {
+                                                  "scale": 2,
+                                                  "precision": 15,
+                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                              },
+                                              "input": {
+                                                "literal": {
+                                                  "i8": 1
+                                                }
+                                              },
+                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                            }
+                                          }
+                                        },
+                                        {
+                                          "value": {
+                                            "selection": {
+                                              "directReference": {
+                                                "structField": {
+                                                  "field": 6
+                                                }
+                                              },
+                                              "rootReference": {}
+                                            }
                                           }
                                         }
-                                      }
-                                    ]
+                                      ]
+                                    }
                                   }
                                 }
-                              }
-                            ]
+                              ]
+                            }
                           }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
-                }
+                ]
               }
             },
-            "groupings": [
-              {}
-            ],
-            "measures": [
+            "expressions": [
               {
-                "measure": {
-                  "functionReference": 7,
-                  "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                  "outputType": {
-                    "decimal": {
-                      "scale": 2,
-                      "precision": 38,
-                      "nullability": "NULLABILITY_NULLABLE"
-                    }
+                "selection": {
+                  "directReference": {
+                    "structField": {}
                   },
-                  "arguments": [
-                    {
-                      "value": {
-                        "scalarFunction": {
-                          "functionReference": 8,
-                          "outputType": {
-                            "decimal": {
-                              "scale": 2,
-                              "precision": 15,
-                              "nullability": "NULLABILITY_NULLABLE"
-                            }
-                          },
-                          "arguments": [
-                            {
-                              "value": {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 5
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              }
-                            },
-                            {
-                              "value": {
-                                "scalarFunction": {
-                                  "functionReference": 9,
-                                  "outputType": {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "value": {
-                                        "cast": {
-                                          "type": {
-                                            "decimal": {
-                                              "scale": 2,
-                                              "precision": 15,
-                                              "nullability": "NULLABILITY_NULLABLE"
-                                            }
-                                          },
-                                          "input": {
-                                            "literal": {
-                                              "i8": 1
-                                            }
-                                          },
-                                          "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                        }
-                                      }
-                                    },
-                                    {
-                                      "value": {
-                                        "selection": {
-                                          "directReference": {
-                                            "structField": {
-                                              "field": 6
-                                            }
-                                          },
-                                          "rootReference": {}
-                                        }
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  ]
+                  "rootReference": {}
                 }
               }
             ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
@@ -693,345 +693,366 @@
                                                                     "subquery": {
                                                                       "scalar": {
                                                                         "input": {
-                                                                          "aggregate": {
+                                                                          "project": {
+                                                                            "common": {
+                                                                              "emit": {
+                                                                                "outputMapping": [
+                                                                                  1
+                                                                                ]
+                                                                              }
+                                                                            },
                                                                             "input": {
-                                                                              "filter": {
+                                                                              "aggregate": {
                                                                                 "input": {
-                                                                                  "read": {
-                                                                                    "common": {
-                                                                                      "direct": {}
-                                                                                    },
-                                                                                    "baseSchema": {
-                                                                                      "names": [
-                                                                                        "l_orderkey",
-                                                                                        "l_partkey",
-                                                                                        "l_suppkey",
-                                                                                        "l_linenumber",
-                                                                                        "l_quantity",
-                                                                                        "l_extendedprice",
-                                                                                        "l_discount",
-                                                                                        "l_tax",
-                                                                                        "l_returnflag",
-                                                                                        "l_linestatus",
-                                                                                        "l_shipdate",
-                                                                                        "l_commitdate",
-                                                                                        "l_receiptdate",
-                                                                                        "l_shipinstruct",
-                                                                                        "l_shipmode",
-                                                                                        "l_comment"
-                                                                                      ],
-                                                                                      "struct": {
-                                                                                        "types": [
-                                                                                          {
-                                                                                            "i64": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "i64": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "i64": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "i64": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "decimal": {
-                                                                                              "scale": 2,
-                                                                                              "precision": 15,
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "decimal": {
-                                                                                              "scale": 2,
-                                                                                              "precision": 15,
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "decimal": {
-                                                                                              "scale": 2,
-                                                                                              "precision": 15,
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "decimal": {
-                                                                                              "scale": 2,
-                                                                                              "precision": 15,
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "string": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "string": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "date": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "date": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "date": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "string": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "string": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
-                                                                                          },
-                                                                                          {
-                                                                                            "string": {
-                                                                                              "nullability": "NULLABILITY_NULLABLE"
-                                                                                            }
+                                                                                  "filter": {
+                                                                                    "input": {
+                                                                                      "read": {
+                                                                                        "common": {
+                                                                                          "direct": {}
+                                                                                        },
+                                                                                        "baseSchema": {
+                                                                                          "names": [
+                                                                                            "l_orderkey",
+                                                                                            "l_partkey",
+                                                                                            "l_suppkey",
+                                                                                            "l_linenumber",
+                                                                                            "l_quantity",
+                                                                                            "l_extendedprice",
+                                                                                            "l_discount",
+                                                                                            "l_tax",
+                                                                                            "l_returnflag",
+                                                                                            "l_linestatus",
+                                                                                            "l_shipdate",
+                                                                                            "l_commitdate",
+                                                                                            "l_receiptdate",
+                                                                                            "l_shipinstruct",
+                                                                                            "l_shipmode",
+                                                                                            "l_comment"
+                                                                                          ],
+                                                                                          "struct": {
+                                                                                            "types": [
+                                                                                              {
+                                                                                                "i64": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "i64": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "i64": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "i64": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "decimal": {
+                                                                                                  "scale": 2,
+                                                                                                  "precision": 15,
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "decimal": {
+                                                                                                  "scale": 2,
+                                                                                                  "precision": 15,
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "decimal": {
+                                                                                                  "scale": 2,
+                                                                                                  "precision": 15,
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "decimal": {
+                                                                                                  "scale": 2,
+                                                                                                  "precision": 15,
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "string": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "string": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "date": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "date": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "date": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "string": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "string": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              {
+                                                                                                "string": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              }
+                                                                                            ],
+                                                                                            "nullability": "NULLABILITY_REQUIRED"
                                                                                           }
-                                                                                        ],
-                                                                                        "nullability": "NULLABILITY_REQUIRED"
+                                                                                        },
+                                                                                        "namedTable": {
+                                                                                          "names": [
+                                                                                            "lineitem"
+                                                                                          ]
+                                                                                        }
                                                                                       }
                                                                                     },
-                                                                                    "namedTable": {
-                                                                                      "names": [
-                                                                                        "lineitem"
-                                                                                      ]
+                                                                                    "condition": {
+                                                                                      "scalarFunction": {
+                                                                                        "functionReference": 2,
+                                                                                        "outputType": {
+                                                                                          "bool": {
+                                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                                          }
+                                                                                        },
+                                                                                        "arguments": [
+                                                                                          {
+                                                                                            "value": {
+                                                                                              "scalarFunction": {
+                                                                                                "functionReference": 2,
+                                                                                                "outputType": {
+                                                                                                  "bool": {
+                                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                                  }
+                                                                                                },
+                                                                                                "arguments": [
+                                                                                                  {
+                                                                                                    "value": {
+                                                                                                      "scalarFunction": {
+                                                                                                        "functionReference": 2,
+                                                                                                        "outputType": {
+                                                                                                          "bool": {
+                                                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "arguments": [
+                                                                                                          {
+                                                                                                            "value": {
+                                                                                                              "scalarFunction": {
+                                                                                                                "functionReference": 1,
+                                                                                                                "outputType": {
+                                                                                                                  "bool": {
+                                                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "arguments": [
+                                                                                                                  {
+                                                                                                                    "value": {
+                                                                                                                      "selection": {
+                                                                                                                        "directReference": {
+                                                                                                                          "structField": {
+                                                                                                                            "field": 1
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "rootReference": {}
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "value": {
+                                                                                                                      "selection": {
+                                                                                                                        "directReference": {
+                                                                                                                          "structField": {}
+                                                                                                                        },
+                                                                                                                        "rootReference": {}
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "value": {
+                                                                                                              "scalarFunction": {
+                                                                                                                "functionReference": 1,
+                                                                                                                "outputType": {
+                                                                                                                  "bool": {
+                                                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "arguments": [
+                                                                                                                  {
+                                                                                                                    "value": {
+                                                                                                                      "selection": {
+                                                                                                                        "directReference": {
+                                                                                                                          "structField": {
+                                                                                                                            "field": 2
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "rootReference": {}
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  {
+                                                                                                                    "value": {
+                                                                                                                      "selection": {
+                                                                                                                        "directReference": {
+                                                                                                                          "structField": {
+                                                                                                                            "field": 1
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "rootReference": {}
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "value": {
+                                                                                                      "scalarFunction": {
+                                                                                                        "functionReference": 6,
+                                                                                                        "outputType": {
+                                                                                                          "bool": {
+                                                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "arguments": [
+                                                                                                          {
+                                                                                                            "value": {
+                                                                                                              "selection": {
+                                                                                                                "directReference": {
+                                                                                                                  "structField": {
+                                                                                                                    "field": 10
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "rootReference": {}
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          {
+                                                                                                            "value": {
+                                                                                                              "literal": {
+                                                                                                                "string": "1994-01-01"
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          {
+                                                                                            "value": {
+                                                                                              "scalarFunction": {
+                                                                                                "functionReference": 7,
+                                                                                                "outputType": {
+                                                                                                  "bool": {
+                                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                                  }
+                                                                                                },
+                                                                                                "arguments": [
+                                                                                                  {
+                                                                                                    "value": {
+                                                                                                      "selection": {
+                                                                                                        "directReference": {
+                                                                                                          "structField": {
+                                                                                                            "field": 10
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "rootReference": {}
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "value": {
+                                                                                                      "literal": {
+                                                                                                        "string": "1995-01-01"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        ]
+                                                                                      }
                                                                                     }
                                                                                   }
                                                                                 },
-                                                                                "condition": {
-                                                                                  "scalarFunction": {
-                                                                                    "functionReference": 2,
-                                                                                    "outputType": {
-                                                                                      "bool": {
-                                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                                      }
-                                                                                    },
-                                                                                    "arguments": [
-                                                                                      {
-                                                                                        "value": {
-                                                                                          "scalarFunction": {
-                                                                                            "functionReference": 2,
-                                                                                            "outputType": {
-                                                                                              "bool": {
-                                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                                              }
-                                                                                            },
-                                                                                            "arguments": [
-                                                                                              {
-                                                                                                "value": {
-                                                                                                  "scalarFunction": {
-                                                                                                    "functionReference": 2,
-                                                                                                    "outputType": {
-                                                                                                      "bool": {
-                                                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                                                      }
-                                                                                                    },
-                                                                                                    "arguments": [
-                                                                                                      {
-                                                                                                        "value": {
-                                                                                                          "scalarFunction": {
-                                                                                                            "functionReference": 1,
-                                                                                                            "outputType": {
-                                                                                                              "bool": {
-                                                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                                                              }
-                                                                                                            },
-                                                                                                            "arguments": [
-                                                                                                              {
-                                                                                                                "value": {
-                                                                                                                  "selection": {
-                                                                                                                    "directReference": {
-                                                                                                                      "structField": {
-                                                                                                                        "field": 1
-                                                                                                                      }
-                                                                                                                    },
-                                                                                                                    "rootReference": {}
-                                                                                                                  }
-                                                                                                                }
-                                                                                                              },
-                                                                                                              {
-                                                                                                                "value": {
-                                                                                                                  "selection": {
-                                                                                                                    "directReference": {
-                                                                                                                      "structField": {}
-                                                                                                                    },
-                                                                                                                    "rootReference": {}
-                                                                                                                  }
-                                                                                                                }
-                                                                                                              }
-                                                                                                            ]
-                                                                                                          }
-                                                                                                        }
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "value": {
-                                                                                                          "scalarFunction": {
-                                                                                                            "functionReference": 1,
-                                                                                                            "outputType": {
-                                                                                                              "bool": {
-                                                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                                                              }
-                                                                                                            },
-                                                                                                            "arguments": [
-                                                                                                              {
-                                                                                                                "value": {
-                                                                                                                  "selection": {
-                                                                                                                    "directReference": {
-                                                                                                                      "structField": {
-                                                                                                                        "field": 2
-                                                                                                                      }
-                                                                                                                    },
-                                                                                                                    "rootReference": {}
-                                                                                                                  }
-                                                                                                                }
-                                                                                                              },
-                                                                                                              {
-                                                                                                                "value": {
-                                                                                                                  "selection": {
-                                                                                                                    "directReference": {
-                                                                                                                      "structField": {
-                                                                                                                        "field": 1
-                                                                                                                      }
-                                                                                                                    },
-                                                                                                                    "rootReference": {}
-                                                                                                                  }
-                                                                                                                }
-                                                                                                              }
-                                                                                                            ]
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                }
-                                                                                              },
-                                                                                              {
-                                                                                                "value": {
-                                                                                                  "scalarFunction": {
-                                                                                                    "functionReference": 6,
-                                                                                                    "outputType": {
-                                                                                                      "bool": {
-                                                                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                                                                      }
-                                                                                                    },
-                                                                                                    "arguments": [
-                                                                                                      {
-                                                                                                        "value": {
-                                                                                                          "selection": {
-                                                                                                            "directReference": {
-                                                                                                              "structField": {
-                                                                                                                "field": 10
-                                                                                                              }
-                                                                                                            },
-                                                                                                            "rootReference": {}
-                                                                                                          }
-                                                                                                        }
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "value": {
-                                                                                                          "literal": {
-                                                                                                            "string": "1994-01-01"
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            ]
-                                                                                          }
+                                                                                "groupings": [
+                                                                                  {}
+                                                                                ],
+                                                                                "measures": [
+                                                                                  {
+                                                                                    "measure": {
+                                                                                      "functionReference": 8,
+                                                                                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                                                      "outputType": {
+                                                                                        "decimal": {
+                                                                                          "scale": 2,
+                                                                                          "precision": 38,
+                                                                                          "nullability": "NULLABILITY_NULLABLE"
                                                                                         }
                                                                                       },
-                                                                                      {
-                                                                                        "value": {
-                                                                                          "scalarFunction": {
-                                                                                            "functionReference": 7,
-                                                                                            "outputType": {
-                                                                                              "bool": {
-                                                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                                                              }
-                                                                                            },
-                                                                                            "arguments": [
-                                                                                              {
-                                                                                                "value": {
-                                                                                                  "selection": {
-                                                                                                    "directReference": {
-                                                                                                      "structField": {
-                                                                                                        "field": 10
-                                                                                                      }
-                                                                                                    },
-                                                                                                    "rootReference": {}
-                                                                                                  }
+                                                                                      "arguments": [
+                                                                                        {
+                                                                                          "value": {
+                                                                                            "selection": {
+                                                                                              "directReference": {
+                                                                                                "structField": {
+                                                                                                  "field": 4
                                                                                                 }
                                                                                               },
-                                                                                              {
-                                                                                                "value": {
-                                                                                                  "literal": {
-                                                                                                    "string": "1995-01-01"
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            ]
+                                                                                              "rootReference": {}
+                                                                                            }
                                                                                           }
                                                                                         }
-                                                                                      }
-                                                                                    ]
+                                                                                      ]
+                                                                                    }
                                                                                   }
-                                                                                }
+                                                                                ]
                                                                               }
                                                                             },
-                                                                            "groupings": [
-                                                                              {}
-                                                                            ],
-                                                                            "measures": [
+                                                                            "expressions": [
                                                                               {
-                                                                                "measure": {
-                                                                                  "functionReference": 8,
-                                                                                  "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                                                  "outputType": {
-                                                                                    "decimal": {
-                                                                                      "scale": 2,
-                                                                                      "precision": 38,
-                                                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                                                    }
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {}
                                                                                   },
-                                                                                  "arguments": [
-                                                                                    {
-                                                                                      "value": {
-                                                                                        "selection": {
-                                                                                          "directReference": {
-                                                                                            "structField": {
-                                                                                              "field": 4
-                                                                                            }
-                                                                                          },
-                                                                                          "rootReference": {}
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  ]
+                                                                                  "rootReference": {}
                                                                                 }
                                                                               }
                                                                             ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
@@ -65,93 +65,265 @@
             "input": {
               "sort": {
                 "input": {
-                  "aggregate": {
+                  "project": {
+                    "common": {
+                      "emit": {
+                        "outputMapping": [
+                          2,
+                          3
+                        ]
+                      }
+                    },
                     "input": {
-                      "filter": {
+                      "aggregate": {
                         "input": {
-                          "project": {
-                            "common": {
-                              "emit": {
-                                "outputMapping": [
-                                  36,
-                                  37,
-                                  38,
-                                  39,
-                                  40,
-                                  41,
-                                  42
-                                ]
-                              }
-                            },
+                          "filter": {
                             "input": {
-                              "join": {
-                                "left": {
+                              "project": {
+                                "common": {
+                                  "emit": {
+                                    "outputMapping": [
+                                      36,
+                                      37,
+                                      38,
+                                      39,
+                                      40,
+                                      41,
+                                      42
+                                    ]
+                                  }
+                                },
+                                "input": {
                                   "join": {
                                     "left": {
                                       "join": {
                                         "left": {
-                                          "read": {
-                                            "common": {
-                                              "direct": {}
-                                            },
-                                            "baseSchema": {
-                                              "names": [
-                                                "s_suppkey",
-                                                "s_name",
-                                                "s_address",
-                                                "s_nationkey",
-                                                "s_phone",
-                                                "s_acctbal",
-                                                "s_comment"
-                                              ],
-                                              "struct": {
-                                                "types": [
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i32": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
-                                                  },
-                                                  {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                    }
+                                          "join": {
+                                            "left": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "s_suppkey",
+                                                    "s_name",
+                                                    "s_address",
+                                                    "s_nationkey",
+                                                    "s_phone",
+                                                    "s_acctbal",
+                                                    "s_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i32": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_REQUIRED"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
                                                   }
-                                                ],
-                                                "nullability": "NULLABILITY_REQUIRED"
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "supplier"
+                                                  ]
+                                                }
                                               }
                                             },
-                                            "namedTable": {
-                                              "names": [
-                                                "supplier"
-                                              ]
-                                            }
+                                            "right": {
+                                              "read": {
+                                                "common": {
+                                                  "direct": {}
+                                                },
+                                                "baseSchema": {
+                                                  "names": [
+                                                    "l_orderkey",
+                                                    "l_partkey",
+                                                    "l_suppkey",
+                                                    "l_linenumber",
+                                                    "l_quantity",
+                                                    "l_extendedprice",
+                                                    "l_discount",
+                                                    "l_tax",
+                                                    "l_returnflag",
+                                                    "l_linestatus",
+                                                    "l_shipdate",
+                                                    "l_commitdate",
+                                                    "l_receiptdate",
+                                                    "l_shipinstruct",
+                                                    "l_shipmode",
+                                                    "l_comment"
+                                                  ],
+                                                  "struct": {
+                                                    "types": [
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "i64": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "decimal": {
+                                                          "scale": 2,
+                                                          "precision": 15,
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "date": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      },
+                                                      {
+                                                        "string": {
+                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                      }
+                                                    ],
+                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                  }
+                                                },
+                                                "namedTable": {
+                                                  "names": [
+                                                    "lineitem"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "expression": {
+                                              "scalarFunction": {
+                                                "functionReference": 1,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {}
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "selection": {
+                                                        "directReference": {
+                                                          "structField": {
+                                                            "field": 9
+                                                          }
+                                                        },
+                                                        "rootReference": {}
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "JOIN_TYPE_INNER"
                                           }
                                         },
                                         "right": {
@@ -161,111 +333,63 @@
                                             },
                                             "baseSchema": {
                                               "names": [
-                                                "l_orderkey",
-                                                "l_partkey",
-                                                "l_suppkey",
-                                                "l_linenumber",
-                                                "l_quantity",
-                                                "l_extendedprice",
-                                                "l_discount",
-                                                "l_tax",
-                                                "l_returnflag",
-                                                "l_linestatus",
-                                                "l_shipdate",
-                                                "l_commitdate",
-                                                "l_receiptdate",
-                                                "l_shipinstruct",
-                                                "l_shipmode",
-                                                "l_comment"
+                                                "o_orderkey",
+                                                "o_custkey",
+                                                "o_orderstatus",
+                                                "o_totalprice",
+                                                "o_orderdate",
+                                                "o_orderpriority",
+                                                "o_clerk",
+                                                "o_shippriority",
+                                                "o_comment"
                                               ],
                                               "struct": {
                                                 "types": [
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "i64": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "decimal": {
-                                                      "scale": 2,
-                                                      "precision": 15,
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
-                                                    "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                    "decimal": {
+                                                      "scale": 2,
+                                                      "precision": 15,
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                    }
-                                                  },
-                                                  {
-                                                    "date": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
+                                                    }
+                                                  },
+                                                  {
+                                                    "i32": {
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   },
                                                   {
                                                     "string": {
-                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                      "nullability": "NULLABILITY_REQUIRED"
                                                     }
                                                   }
                                                 ],
@@ -274,7 +398,7 @@
                                             },
                                             "namedTable": {
                                               "names": [
-                                                "lineitem"
+                                                "orders"
                                               ]
                                             }
                                           }
@@ -292,7 +416,9 @@
                                                 "value": {
                                                   "selection": {
                                                     "directReference": {
-                                                      "structField": {}
+                                                      "structField": {
+                                                        "field": 23
+                                                      }
                                                     },
                                                     "rootReference": {}
                                                   }
@@ -303,7 +429,7 @@
                                                   "selection": {
                                                     "directReference": {
                                                       "structField": {
-                                                        "field": 9
+                                                        "field": 7
                                                       }
                                                     },
                                                     "rootReference": {}
@@ -323,47 +449,15 @@
                                         },
                                         "baseSchema": {
                                           "names": [
-                                            "o_orderkey",
-                                            "o_custkey",
-                                            "o_orderstatus",
-                                            "o_totalprice",
-                                            "o_orderdate",
-                                            "o_orderpriority",
-                                            "o_clerk",
-                                            "o_shippriority",
-                                            "o_comment"
+                                            "n_nationkey",
+                                            "n_name",
+                                            "n_regionkey",
+                                            "n_comment"
                                           ],
                                           "struct": {
                                             "types": [
                                               {
                                                 "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "i32": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "decimal": {
-                                                  "scale": 2,
-                                                  "precision": 15,
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "date": {
-                                                  "nullability": "NULLABILITY_REQUIRED"
-                                                }
-                                              },
-                                              {
-                                                "string": {
                                                   "nullability": "NULLABILITY_REQUIRED"
                                                 }
                                               },
@@ -388,7 +482,7 @@
                                         },
                                         "namedTable": {
                                           "names": [
-                                            "orders"
+                                            "nation"
                                           ]
                                         }
                                       }
@@ -407,7 +501,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 23
+                                                    "field": 3
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -419,7 +513,7 @@
                                               "selection": {
                                                 "directReference": {
                                                   "structField": {
-                                                    "field": 7
+                                                    "field": 32
                                                   }
                                                 },
                                                 "rootReference": {}
@@ -432,864 +526,802 @@
                                     "type": "JOIN_TYPE_INNER"
                                   }
                                 },
-                                "right": {
-                                  "read": {
-                                    "common": {
-                                      "direct": {}
-                                    },
-                                    "baseSchema": {
-                                      "names": [
-                                        "n_nationkey",
-                                        "n_name",
-                                        "n_regionkey",
-                                        "n_comment"
-                                      ],
-                                      "struct": {
-                                        "types": [
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "i32": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          },
-                                          {
-                                            "string": {
-                                              "nullability": "NULLABILITY_REQUIRED"
-                                            }
-                                          }
-                                        ],
-                                        "nullability": "NULLABILITY_REQUIRED"
-                                      }
-                                    },
-                                    "namedTable": {
-                                      "names": [
-                                        "nation"
-                                      ]
-                                    }
-                                  }
-                                },
-                                "expression": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 3
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                "expressions": [
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 7
                                         }
                                       },
-                                      {
-                                        "value": {
-                                          "selection": {
-                                            "directReference": {
-                                              "structField": {
-                                                "field": 32
-                                              }
-                                            },
-                                            "rootReference": {}
-                                          }
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 25
                                         }
-                                      }
-                                    ]
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 19
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 18
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 9
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 1
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  },
+                                  {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 33
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
                                   }
-                                },
-                                "type": "JOIN_TYPE_INNER"
+                                ]
                               }
                             },
-                            "expressions": [
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 7
+                            "condition": {
+                              "scalarFunction": {
+                                "functionReference": 2,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 2,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "scalarFunction": {
+                                                "functionReference": 2,
+                                                "outputType": {
+                                                  "bool": {
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 2,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 1,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 25
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "literal": {
+                                                                        "string": "F"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "scalarFunction": {
+                                                                "functionReference": 3,
+                                                                "outputType": {
+                                                                  "bool": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                "arguments": [
+                                                                  {
+                                                                    "value": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 19
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  {
+                                                                    "value": {
+                                                                      "selection": {
+                                                                        "directReference": {
+                                                                          "structField": {
+                                                                            "field": 18
+                                                                          }
+                                                                        },
+                                                                        "rootReference": {}
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  {
+                                                    "value": {
+                                                      "scalarFunction": {
+                                                        "functionReference": 1,
+                                                        "outputType": {
+                                                          "bool": {
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                          }
+                                                        },
+                                                        "arguments": [
+                                                          {
+                                                            "value": {
+                                                              "selection": {
+                                                                "directReference": {
+                                                                  "structField": {
+                                                                    "field": 33
+                                                                  }
+                                                                },
+                                                                "rootReference": {}
+                                                              }
+                                                            }
+                                                          },
+                                                          {
+                                                            "value": {
+                                                              "literal": {
+                                                                "string": "SAUDI ARABIA"
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "value": {
+                                              "subquery": {
+                                                "setPredicate": {
+                                                  "predicateOp": "PREDICATE_OP_EXISTS",
+                                                  "tuples": {
+                                                    "filter": {
+                                                      "input": {
+                                                        "read": {
+                                                          "common": {
+                                                            "direct": {}
+                                                          },
+                                                          "baseSchema": {
+                                                            "names": [
+                                                              "l_orderkey",
+                                                              "l_partkey",
+                                                              "l_suppkey",
+                                                              "l_linenumber",
+                                                              "l_quantity",
+                                                              "l_extendedprice",
+                                                              "l_discount",
+                                                              "l_tax",
+                                                              "l_returnflag",
+                                                              "l_linestatus",
+                                                              "l_shipdate",
+                                                              "l_commitdate",
+                                                              "l_receiptdate",
+                                                              "l_shipinstruct",
+                                                              "l_shipmode",
+                                                              "l_comment"
+                                                            ],
+                                                            "struct": {
+                                                              "types": [
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          "namedTable": {
+                                                            "names": [
+                                                              "lineitem"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "condition": {
+                                                        "scalarFunction": {
+                                                          "functionReference": 2,
+                                                          "outputType": {
+                                                            "bool": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "arguments": [
+                                                            {
+                                                              "value": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 1,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {}
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 7
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "value": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 4,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 2
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 9
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
                                     }
                                   },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 25
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 5,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "subquery": {
+                                                "setPredicate": {
+                                                  "predicateOp": "PREDICATE_OP_EXISTS",
+                                                  "tuples": {
+                                                    "filter": {
+                                                      "input": {
+                                                        "read": {
+                                                          "common": {
+                                                            "direct": {}
+                                                          },
+                                                          "baseSchema": {
+                                                            "names": [
+                                                              "l_orderkey",
+                                                              "l_partkey",
+                                                              "l_suppkey",
+                                                              "l_linenumber",
+                                                              "l_quantity",
+                                                              "l_extendedprice",
+                                                              "l_discount",
+                                                              "l_tax",
+                                                              "l_returnflag",
+                                                              "l_linestatus",
+                                                              "l_shipdate",
+                                                              "l_commitdate",
+                                                              "l_receiptdate",
+                                                              "l_shipinstruct",
+                                                              "l_shipmode",
+                                                              "l_comment"
+                                                            ],
+                                                            "struct": {
+                                                              "types": [
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i64": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "decimal": {
+                                                                    "scale": 2,
+                                                                    "precision": 15,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          "namedTable": {
+                                                            "names": [
+                                                              "lineitem"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "condition": {
+                                                        "scalarFunction": {
+                                                          "functionReference": 2,
+                                                          "outputType": {
+                                                            "bool": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "arguments": [
+                                                            {
+                                                              "value": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 2,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "scalarFunction": {
+                                                                          "functionReference": 1,
+                                                                          "outputType": {
+                                                                            "bool": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          "arguments": [
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {}
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
+                                                                                      "field": 7
+                                                                                    }
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "scalarFunction": {
+                                                                          "functionReference": 4,
+                                                                          "outputType": {
+                                                                            "bool": {
+                                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                          },
+                                                                          "arguments": [
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
+                                                                                      "field": 2
+                                                                                    }
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            {
+                                                                              "value": {
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
+                                                                                      "field": 9
+                                                                                    }
+                                                                                  },
+                                                                                  "rootReference": {}
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "value": {
+                                                                "scalarFunction": {
+                                                                  "functionReference": 3,
+                                                                  "outputType": {
+                                                                    "bool": {
+                                                                      "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                  },
+                                                                  "arguments": [
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 12
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "value": {
+                                                                        "selection": {
+                                                                          "directReference": {
+                                                                            "structField": {
+                                                                              "field": 11
+                                                                            }
+                                                                          },
+                                                                          "rootReference": {}
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
                                     }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 19
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 18
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 9
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 1
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
-                              },
-                              {
-                                "selection": {
-                                  "directReference": {
-                                    "structField": {
-                                      "field": 33
-                                    }
-                                  },
-                                  "rootReference": {}
-                                }
+                                  }
+                                ]
                               }
-                            ]
+                            }
                           }
                         },
-                        "condition": {
-                          "scalarFunction": {
-                            "functionReference": 2,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
-                              }
-                            },
-                            "arguments": [
+                        "groupings": [
+                          {
+                            "groupingExpressions": [
                               {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 2,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 2,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 2,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 1,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 25
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "literal": {
-                                                                    "string": "F"
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "scalarFunction": {
-                                                            "functionReference": 3,
-                                                            "outputType": {
-                                                              "bool": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 19
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              },
-                                                              {
-                                                                "value": {
-                                                                  "selection": {
-                                                                    "directReference": {
-                                                                      "structField": {
-                                                                        "field": 18
-                                                                      }
-                                                                    },
-                                                                    "rootReference": {}
-                                                                  }
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "scalarFunction": {
-                                                    "functionReference": 1,
-                                                    "outputType": {
-                                                      "bool": {
-                                                        "nullability": "NULLABILITY_NULLABLE"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "value": {
-                                                          "selection": {
-                                                            "directReference": {
-                                                              "structField": {
-                                                                "field": 33
-                                                              }
-                                                            },
-                                                            "rootReference": {}
-                                                          }
-                                                        }
-                                                      },
-                                                      {
-                                                        "value": {
-                                                          "literal": {
-                                                            "string": "SAUDI ARABIA"
-                                                          }
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "subquery": {
-                                            "setPredicate": {
-                                              "predicateOp": "PREDICATE_OP_EXISTS",
-                                              "tuples": {
-                                                "filter": {
-                                                  "input": {
-                                                    "read": {
-                                                      "common": {
-                                                        "direct": {}
-                                                      },
-                                                      "baseSchema": {
-                                                        "names": [
-                                                          "l_orderkey",
-                                                          "l_partkey",
-                                                          "l_suppkey",
-                                                          "l_linenumber",
-                                                          "l_quantity",
-                                                          "l_extendedprice",
-                                                          "l_discount",
-                                                          "l_tax",
-                                                          "l_returnflag",
-                                                          "l_linestatus",
-                                                          "l_shipdate",
-                                                          "l_commitdate",
-                                                          "l_receiptdate",
-                                                          "l_shipinstruct",
-                                                          "l_shipmode",
-                                                          "l_comment"
-                                                        ],
-                                                        "struct": {
-                                                          "types": [
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            }
-                                                          ],
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      "namedTable": {
-                                                        "names": [
-                                                          "lineitem"
-                                                        ]
-                                                      }
-                                                    }
-                                                  },
-                                                  "condition": {
-                                                    "scalarFunction": {
-                                                      "functionReference": 2,
-                                                      "outputType": {
-                                                        "bool": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "arguments": [
-                                                        {
-                                                          "value": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 1,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {}
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 7
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
-                                                                  }
-                                                                }
-                                                              ]
-                                                            }
-                                                          }
-                                                        },
-                                                        {
-                                                          "value": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 4,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 2
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 9
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
-                                                                  }
-                                                                }
-                                                              ]
-                                                            }
-                                                          }
-                                                        }
-                                                      ]
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 5,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "subquery": {
-                                            "setPredicate": {
-                                              "predicateOp": "PREDICATE_OP_EXISTS",
-                                              "tuples": {
-                                                "filter": {
-                                                  "input": {
-                                                    "read": {
-                                                      "common": {
-                                                        "direct": {}
-                                                      },
-                                                      "baseSchema": {
-                                                        "names": [
-                                                          "l_orderkey",
-                                                          "l_partkey",
-                                                          "l_suppkey",
-                                                          "l_linenumber",
-                                                          "l_quantity",
-                                                          "l_extendedprice",
-                                                          "l_discount",
-                                                          "l_tax",
-                                                          "l_returnflag",
-                                                          "l_linestatus",
-                                                          "l_shipdate",
-                                                          "l_commitdate",
-                                                          "l_receiptdate",
-                                                          "l_shipinstruct",
-                                                          "l_shipmode",
-                                                          "l_comment"
-                                                        ],
-                                                        "struct": {
-                                                          "types": [
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i64": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_NULLABLE"
-                                                              }
-                                                            }
-                                                          ],
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      "namedTable": {
-                                                        "names": [
-                                                          "lineitem"
-                                                        ]
-                                                      }
-                                                    }
-                                                  },
-                                                  "condition": {
-                                                    "scalarFunction": {
-                                                      "functionReference": 2,
-                                                      "outputType": {
-                                                        "bool": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "arguments": [
-                                                        {
-                                                          "value": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 2,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "value": {
-                                                                    "scalarFunction": {
-                                                                      "functionReference": 1,
-                                                                      "outputType": {
-                                                                        "bool": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      "arguments": [
-                                                                        {
-                                                                          "value": {
-                                                                            "selection": {
-                                                                              "directReference": {
-                                                                                "structField": {}
-                                                                              },
-                                                                              "rootReference": {}
-                                                                            }
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "value": {
-                                                                            "selection": {
-                                                                              "directReference": {
-                                                                                "structField": {
-                                                                                  "field": 7
-                                                                                }
-                                                                              },
-                                                                              "rootReference": {}
-                                                                            }
-                                                                          }
-                                                                        }
-                                                                      ]
-                                                                    }
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "value": {
-                                                                    "scalarFunction": {
-                                                                      "functionReference": 4,
-                                                                      "outputType": {
-                                                                        "bool": {
-                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                        }
-                                                                      },
-                                                                      "arguments": [
-                                                                        {
-                                                                          "value": {
-                                                                            "selection": {
-                                                                              "directReference": {
-                                                                                "structField": {
-                                                                                  "field": 2
-                                                                                }
-                                                                              },
-                                                                              "rootReference": {}
-                                                                            }
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "value": {
-                                                                            "selection": {
-                                                                              "directReference": {
-                                                                                "structField": {
-                                                                                  "field": 9
-                                                                                }
-                                                                              },
-                                                                              "rootReference": {}
-                                                                            }
-                                                                          }
-                                                                        }
-                                                                      ]
-                                                                    }
-                                                                  }
-                                                                }
-                                                              ]
-                                                            }
-                                                          }
-                                                        },
-                                                        {
-                                                          "value": {
-                                                            "scalarFunction": {
-                                                              "functionReference": 3,
-                                                              "outputType": {
-                                                                "bool": {
-                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 12
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
-                                                                  }
-                                                                },
-                                                                {
-                                                                  "value": {
-                                                                    "selection": {
-                                                                      "directReference": {
-                                                                        "structField": {
-                                                                          "field": 11
-                                                                        }
-                                                                      },
-                                                                      "rootReference": {}
-                                                                    }
-                                                                  }
-                                                                }
-                                                              ]
-                                                            }
-                                                          }
-                                                        }
-                                                      ]
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
+                                "selection": {
+                                  "directReference": {
+                                    "structField": {
+                                      "field": 5
+                                    }
+                                  },
+                                  "rootReference": {}
                                 }
                               }
                             ]
                           }
-                        }
-                      }
-                    },
-                    "groupings": [
-                      {
-                        "groupingExpressions": [
+                        ],
+                        "measures": [
                           {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 5
+                            "measure": {
+                              "functionReference": 6,
+                              "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                              "outputType": {
+                                "i64": {
+                                  "nullability": "NULLABILITY_NULLABLE"
                                 }
-                              },
-                              "rootReference": {}
+                              }
                             }
                           }
                         ]
                       }
-                    ],
-                    "measures": [
+                    },
+                    "expressions": [
                       {
-                        "measure": {
-                          "functionReference": 6,
-                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                          "outputType": {
-                            "i64": {
-                              "nullability": "NULLABILITY_NULLABLE"
+                        "selection": {
+                          "directReference": {
+                            "structField": {}
+                          },
+                          "rootReference": {}
+                        }
+                      },
+                      {
+                        "selection": {
+                          "directReference": {
+                            "structField": {
+                              "field": 1
                             }
-                          }
+                          },
+                          "rootReference": {}
                         }
                       }
                     ]

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
@@ -85,117 +85,227 @@
         "input": {
           "sort": {
             "input": {
-              "aggregate": {
+              "project": {
+                "common": {
+                  "emit": {
+                    "outputMapping": [
+                      3,
+                      4,
+                      5
+                    ]
+                  }
+                },
                 "input": {
-                  "project": {
-                    "common": {
-                      "emit": {
-                        "outputMapping": [
-                          8,
-                          9
-                        ]
-                      }
-                    },
+                  "aggregate": {
                     "input": {
-                      "filter": {
-                        "input": {
-                          "read": {
-                            "common": {
-                              "direct": {}
-                            },
-                            "baseSchema": {
-                              "names": [
-                                "c_custkey",
-                                "c_name",
-                                "c_address",
-                                "c_nationkey",
-                                "c_phone",
-                                "c_acctbal",
-                                "c_mktsegment",
-                                "c_comment"
-                              ],
-                              "struct": {
-                                "types": [
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "decimal": {
-                                      "scale": 2,
-                                      "precision": 15,
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  },
-                                  {
-                                    "string": {
-                                      "nullability": "NULLABILITY_REQUIRED"
-                                    }
-                                  }
-                                ],
-                                "nullability": "NULLABILITY_REQUIRED"
-                              }
-                            },
-                            "namedTable": {
-                              "names": [
-                                "customer"
-                              ]
-                            }
+                      "project": {
+                        "common": {
+                          "emit": {
+                            "outputMapping": [
+                              8,
+                              9
+                            ]
                           }
                         },
-                        "condition": {
-                          "scalarFunction": {
-                            "functionReference": 1,
-                            "outputType": {
-                              "bool": {
-                                "nullability": "NULLABILITY_NULLABLE"
+                        "input": {
+                          "filter": {
+                            "input": {
+                              "read": {
+                                "common": {
+                                  "direct": {}
+                                },
+                                "baseSchema": {
+                                  "names": [
+                                    "c_custkey",
+                                    "c_name",
+                                    "c_address",
+                                    "c_nationkey",
+                                    "c_phone",
+                                    "c_acctbal",
+                                    "c_mktsegment",
+                                    "c_comment"
+                                  ],
+                                  "struct": {
+                                    "types": [
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "decimal": {
+                                          "scale": 2,
+                                          "precision": 15,
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      },
+                                      {
+                                        "string": {
+                                          "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                      }
+                                    ],
+                                    "nullability": "NULLABILITY_REQUIRED"
+                                  }
+                                },
+                                "namedTable": {
+                                  "names": [
+                                    "customer"
+                                  ]
+                                }
                               }
                             },
-                            "arguments": [
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 1,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "singularOrList": {
+                            "condition": {
+                              "scalarFunction": {
+                                "functionReference": 1,
+                                "outputType": {
+                                  "bool": {
+                                    "nullability": "NULLABILITY_NULLABLE"
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 1,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "singularOrList": {
+                                                "value": {
+                                                  "scalarFunction": {
+                                                    "functionReference": 2,
+                                                    "outputType": {
+                                                      "string": {
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                      }
+                                                    },
+                                                    "arguments": [
+                                                      {
+                                                        "value": {
+                                                          "selection": {
+                                                            "directReference": {
+                                                              "structField": {
+                                                                "field": 4
+                                                              }
+                                                            },
+                                                            "rootReference": {}
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "cast": {
+                                                            "type": {
+                                                              "i32": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            "input": {
+                                                              "literal": {
+                                                                "i8": 0
+                                                              }
+                                                            },
+                                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                          }
+                                                        }
+                                                      },
+                                                      {
+                                                        "value": {
+                                                          "cast": {
+                                                            "type": {
+                                                              "i32": {
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                              }
+                                                            },
+                                                            "input": {
+                                                              "literal": {
+                                                                "i8": 2
+                                                              }
+                                                            },
+                                                            "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "options": [
+                                                  {
+                                                    "literal": {
+                                                      "string": "13"
+                                                    }
+                                                  },
+                                                  {
+                                                    "literal": {
+                                                      "string": "31"
+                                                    }
+                                                  },
+                                                  {
+                                                    "literal": {
+                                                      "string": "23"
+                                                    }
+                                                  },
+                                                  {
+                                                    "literal": {
+                                                      "string": "29"
+                                                    }
+                                                  },
+                                                  {
+                                                    "literal": {
+                                                      "string": "30"
+                                                    }
+                                                  },
+                                                  {
+                                                    "literal": {
+                                                      "string": "18"
+                                                    }
+                                                  },
+                                                  {
+                                                    "literal": {
+                                                      "string": "17"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
                                             "value": {
                                               "scalarFunction": {
-                                                "functionReference": 2,
+                                                "functionReference": 3,
                                                 "outputType": {
-                                                  "string": {
+                                                  "bool": {
                                                     "nullability": "NULLABILITY_NULLABLE"
                                                   }
                                                 },
@@ -205,7 +315,7 @@
                                                       "selection": {
                                                         "directReference": {
                                                           "structField": {
-                                                            "field": 4
+                                                            "field": 5
                                                           }
                                                         },
                                                         "rootReference": {}
@@ -214,195 +324,95 @@
                                                   },
                                                   {
                                                     "value": {
-                                                      "cast": {
-                                                        "type": {
-                                                          "i32": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        "input": {
-                                                          "literal": {
-                                                            "i8": 0
-                                                          }
-                                                        },
-                                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                      }
-                                                    }
-                                                  },
-                                                  {
-                                                    "value": {
-                                                      "cast": {
-                                                        "type": {
-                                                          "i32": {
-                                                            "nullability": "NULLABILITY_NULLABLE"
-                                                          }
-                                                        },
-                                                        "input": {
-                                                          "literal": {
-                                                            "i8": 2
-                                                          }
-                                                        },
-                                                        "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                      }
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            },
-                                            "options": [
-                                              {
-                                                "literal": {
-                                                  "string": "13"
-                                                }
-                                              },
-                                              {
-                                                "literal": {
-                                                  "string": "31"
-                                                }
-                                              },
-                                              {
-                                                "literal": {
-                                                  "string": "23"
-                                                }
-                                              },
-                                              {
-                                                "literal": {
-                                                  "string": "29"
-                                                }
-                                              },
-                                              {
-                                                "literal": {
-                                                  "string": "30"
-                                                }
-                                              },
-                                              {
-                                                "literal": {
-                                                  "string": "18"
-                                                }
-                                              },
-                                              {
-                                                "literal": {
-                                                  "string": "17"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "value": {
-                                          "scalarFunction": {
-                                            "functionReference": 3,
-                                            "outputType": {
-                                              "bool": {
-                                                "nullability": "NULLABILITY_NULLABLE"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "value": {
-                                                  "selection": {
-                                                    "directReference": {
-                                                      "structField": {
-                                                        "field": 5
-                                                      }
-                                                    },
-                                                    "rootReference": {}
-                                                  }
-                                                }
-                                              },
-                                              {
-                                                "value": {
-                                                  "subquery": {
-                                                    "scalar": {
-                                                      "input": {
-                                                        "aggregate": {
+                                                      "subquery": {
+                                                        "scalar": {
                                                           "input": {
-                                                            "filter": {
-                                                              "input": {
-                                                                "read": {
-                                                                  "common": {
-                                                                    "direct": {}
-                                                                  },
-                                                                  "baseSchema": {
-                                                                    "names": [
-                                                                      "c_custkey",
-                                                                      "c_name",
-                                                                      "c_address",
-                                                                      "c_nationkey",
-                                                                      "c_phone",
-                                                                      "c_acctbal",
-                                                                      "c_mktsegment",
-                                                                      "c_comment"
-                                                                    ],
-                                                                    "struct": {
-                                                                      "types": [
-                                                                        {
-                                                                          "i32": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "string": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "string": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "i32": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "string": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "decimal": {
-                                                                            "scale": 2,
-                                                                            "precision": 15,
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "string": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        },
-                                                                        {
-                                                                          "string": {
-                                                                            "nullability": "NULLABILITY_REQUIRED"
-                                                                          }
-                                                                        }
-                                                                      ],
-                                                                      "nullability": "NULLABILITY_REQUIRED"
-                                                                    }
-                                                                  },
-                                                                  "namedTable": {
-                                                                    "names": [
-                                                                      "customer"
-                                                                    ]
-                                                                  }
+                                                            "project": {
+                                                              "common": {
+                                                                "emit": {
+                                                                  "outputMapping": [
+                                                                    1
+                                                                  ]
                                                                 }
                                                               },
-                                                              "condition": {
-                                                                "scalarFunction": {
-                                                                  "functionReference": 1,
-                                                                  "outputType": {
-                                                                    "bool": {
-                                                                      "nullability": "NULLABILITY_NULLABLE"
-                                                                    }
-                                                                  },
-                                                                  "arguments": [
-                                                                    {
-                                                                      "value": {
+                                                              "input": {
+                                                                "aggregate": {
+                                                                  "input": {
+                                                                    "filter": {
+                                                                      "input": {
+                                                                        "read": {
+                                                                          "common": {
+                                                                            "direct": {}
+                                                                          },
+                                                                          "baseSchema": {
+                                                                            "names": [
+                                                                              "c_custkey",
+                                                                              "c_name",
+                                                                              "c_address",
+                                                                              "c_nationkey",
+                                                                              "c_phone",
+                                                                              "c_acctbal",
+                                                                              "c_mktsegment",
+                                                                              "c_comment"
+                                                                            ],
+                                                                            "struct": {
+                                                                              "types": [
+                                                                                {
+                                                                                  "i32": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "i32": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "decimal": {
+                                                                                    "scale": 2,
+                                                                                    "precision": 15,
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                },
+                                                                                {
+                                                                                  "string": {
+                                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                                  }
+                                                                                }
+                                                                              ],
+                                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                                            }
+                                                                          },
+                                                                          "namedTable": {
+                                                                            "names": [
+                                                                              "customer"
+                                                                            ]
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "condition": {
                                                                         "scalarFunction": {
-                                                                          "functionReference": 3,
+                                                                          "functionReference": 1,
                                                                           "outputType": {
                                                                             "bool": {
                                                                               "nullability": "NULLABILITY_NULLABLE"
@@ -411,162 +421,324 @@
                                                                           "arguments": [
                                                                             {
                                                                               "value": {
-                                                                                "selection": {
-                                                                                  "directReference": {
-                                                                                    "structField": {
-                                                                                      "field": 5
+                                                                                "scalarFunction": {
+                                                                                  "functionReference": 3,
+                                                                                  "outputType": {
+                                                                                    "bool": {
+                                                                                      "nullability": "NULLABILITY_NULLABLE"
                                                                                     }
                                                                                   },
-                                                                                  "rootReference": {}
+                                                                                  "arguments": [
+                                                                                    {
+                                                                                      "value": {
+                                                                                        "selection": {
+                                                                                          "directReference": {
+                                                                                            "structField": {
+                                                                                              "field": 5
+                                                                                            }
+                                                                                          },
+                                                                                          "rootReference": {}
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "value": {
+                                                                                        "literal": {
+                                                                                          "fp64": 0.0
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  ]
                                                                                 }
                                                                               }
                                                                             },
                                                                             {
                                                                               "value": {
-                                                                                "literal": {
-                                                                                  "fp64": 0.0
+                                                                                "singularOrList": {
+                                                                                  "value": {
+                                                                                    "scalarFunction": {
+                                                                                      "functionReference": 2,
+                                                                                      "outputType": {
+                                                                                        "string": {
+                                                                                          "nullability": "NULLABILITY_NULLABLE"
+                                                                                        }
+                                                                                      },
+                                                                                      "arguments": [
+                                                                                        {
+                                                                                          "value": {
+                                                                                            "selection": {
+                                                                                              "directReference": {
+                                                                                                "structField": {
+                                                                                                  "field": 4
+                                                                                                }
+                                                                                              },
+                                                                                              "rootReference": {}
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "value": {
+                                                                                            "cast": {
+                                                                                              "type": {
+                                                                                                "i32": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              "input": {
+                                                                                                "literal": {
+                                                                                                  "i8": 0
+                                                                                                }
+                                                                                              },
+                                                                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        {
+                                                                                          "value": {
+                                                                                            "cast": {
+                                                                                              "type": {
+                                                                                                "i32": {
+                                                                                                  "nullability": "NULLABILITY_NULLABLE"
+                                                                                                }
+                                                                                              },
+                                                                                              "input": {
+                                                                                                "literal": {
+                                                                                                  "i8": 2
+                                                                                                }
+                                                                                              },
+                                                                                              "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      ]
+                                                                                    }
+                                                                                  },
+                                                                                  "options": [
+                                                                                    {
+                                                                                      "literal": {
+                                                                                        "string": "13"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "literal": {
+                                                                                        "string": "31"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "literal": {
+                                                                                        "string": "23"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "literal": {
+                                                                                        "string": "29"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "literal": {
+                                                                                        "string": "30"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "literal": {
+                                                                                        "string": "18"
+                                                                                      }
+                                                                                    },
+                                                                                    {
+                                                                                      "literal": {
+                                                                                        "string": "17"
+                                                                                      }
+                                                                                    }
+                                                                                  ]
                                                                                 }
                                                                               }
                                                                             }
                                                                           ]
                                                                         }
                                                                       }
-                                                                    },
+                                                                    }
+                                                                  },
+                                                                  "groupings": [
+                                                                    {}
+                                                                  ],
+                                                                  "measures": [
                                                                     {
-                                                                      "value": {
-                                                                        "singularOrList": {
-                                                                          "value": {
-                                                                            "scalarFunction": {
-                                                                              "functionReference": 2,
-                                                                              "outputType": {
-                                                                                "string": {
-                                                                                  "nullability": "NULLABILITY_NULLABLE"
-                                                                                }
-                                                                              },
-                                                                              "arguments": [
-                                                                                {
-                                                                                  "value": {
-                                                                                    "selection": {
-                                                                                      "directReference": {
-                                                                                        "structField": {
-                                                                                          "field": 4
-                                                                                        }
-                                                                                      },
-                                                                                      "rootReference": {}
-                                                                                    }
+                                                                      "measure": {
+                                                                        "functionReference": 4,
+                                                                        "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                                                                        "outputType": {
+                                                                          "decimal": {
+                                                                            "scale": 2,
+                                                                            "precision": 15,
+                                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                                          }
+                                                                        },
+                                                                        "arguments": [
+                                                                          {
+                                                                            "value": {
+                                                                              "selection": {
+                                                                                "directReference": {
+                                                                                  "structField": {
+                                                                                    "field": 5
                                                                                   }
                                                                                 },
-                                                                                {
-                                                                                  "value": {
-                                                                                    "cast": {
-                                                                                      "type": {
-                                                                                        "i32": {
-                                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                                        }
-                                                                                      },
-                                                                                      "input": {
-                                                                                        "literal": {
-                                                                                          "i8": 0
-                                                                                        }
-                                                                                      },
-                                                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                                                    }
-                                                                                  }
-                                                                                },
-                                                                                {
-                                                                                  "value": {
-                                                                                    "cast": {
-                                                                                      "type": {
-                                                                                        "i32": {
-                                                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                                                        }
-                                                                                      },
-                                                                                      "input": {
-                                                                                        "literal": {
-                                                                                          "i8": 2
-                                                                                        }
-                                                                                      },
-                                                                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                                                                    }
-                                                                                  }
-                                                                                }
-                                                                              ]
-                                                                            }
-                                                                          },
-                                                                          "options": [
-                                                                            {
-                                                                              "literal": {
-                                                                                "string": "13"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "literal": {
-                                                                                "string": "31"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "literal": {
-                                                                                "string": "23"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "literal": {
-                                                                                "string": "29"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "literal": {
-                                                                                "string": "30"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "literal": {
-                                                                                "string": "18"
-                                                                              }
-                                                                            },
-                                                                            {
-                                                                              "literal": {
-                                                                                "string": "17"
+                                                                                "rootReference": {}
                                                                               }
                                                                             }
-                                                                          ]
-                                                                        }
+                                                                          }
+                                                                        ]
                                                                       }
                                                                     }
                                                                   ]
                                                                 }
-                                                              }
+                                                              },
+                                                              "expressions": [
+                                                                {
+                                                                  "selection": {
+                                                                    "directReference": {
+                                                                      "structField": {}
+                                                                    },
+                                                                    "rootReference": {}
+                                                                  }
+                                                                }
+                                                              ]
                                                             }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "value": {
+                                      "scalarFunction": {
+                                        "functionReference": 5,
+                                        "outputType": {
+                                          "bool": {
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "value": {
+                                              "subquery": {
+                                                "setPredicate": {
+                                                  "predicateOp": "PREDICATE_OP_EXISTS",
+                                                  "tuples": {
+                                                    "filter": {
+                                                      "input": {
+                                                        "read": {
+                                                          "common": {
+                                                            "direct": {}
                                                           },
-                                                          "groupings": [
-                                                            {}
-                                                          ],
-                                                          "measures": [
-                                                            {
-                                                              "measure": {
-                                                                "functionReference": 4,
-                                                                "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                                                                "outputType": {
+                                                          "baseSchema": {
+                                                            "names": [
+                                                              "o_orderkey",
+                                                              "o_custkey",
+                                                              "o_orderstatus",
+                                                              "o_totalprice",
+                                                              "o_orderdate",
+                                                              "o_orderpriority",
+                                                              "o_clerk",
+                                                              "o_shippriority",
+                                                              "o_comment"
+                                                            ],
+                                                            "struct": {
+                                                              "types": [
+                                                                {
+                                                                  "i32": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i32": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
                                                                   "decimal": {
                                                                     "scale": 2,
                                                                     "precision": 15,
-                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                    "nullability": "NULLABILITY_REQUIRED"
                                                                   }
                                                                 },
-                                                                "arguments": [
-                                                                  {
-                                                                    "value": {
-                                                                      "selection": {
-                                                                        "directReference": {
-                                                                          "structField": {
-                                                                            "field": 5
-                                                                          }
-                                                                        },
-                                                                        "rootReference": {}
-                                                                      }
-                                                                    }
+                                                                {
+                                                                  "date": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
                                                                   }
-                                                                ]
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "i32": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                },
+                                                                {
+                                                                  "string": {
+                                                                    "nullability": "NULLABILITY_REQUIRED"
+                                                                  }
+                                                                }
+                                                              ],
+                                                              "nullability": "NULLABILITY_REQUIRED"
+                                                            }
+                                                          },
+                                                          "namedTable": {
+                                                            "names": [
+                                                              "orders"
+                                                            ]
+                                                          }
+                                                        }
+                                                      },
+                                                      "condition": {
+                                                        "scalarFunction": {
+                                                          "functionReference": 6,
+                                                          "outputType": {
+                                                            "bool": {
+                                                              "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                          },
+                                                          "arguments": [
+                                                            {
+                                                              "value": {
+                                                                "selection": {
+                                                                  "directReference": {
+                                                                    "structField": {
+                                                                      "field": 1
+                                                                    }
+                                                                  },
+                                                                  "rootReference": {}
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "value": {
+                                                                "selection": {
+                                                                  "directReference": {
+                                                                    "structField": {}
+                                                                  },
+                                                                  "rootReference": {}
+                                                                }
                                                               }
                                                             }
                                                           ]
@@ -576,163 +748,123 @@
                                                   }
                                                 }
                                               }
-                                            ]
-                                          }
-                                        }
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "value": {
-                                  "scalarFunction": {
-                                    "functionReference": 5,
-                                    "outputType": {
-                                      "bool": {
-                                        "nullability": "NULLABILITY_NULLABLE"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "value": {
-                                          "subquery": {
-                                            "setPredicate": {
-                                              "predicateOp": "PREDICATE_OP_EXISTS",
-                                              "tuples": {
-                                                "filter": {
-                                                  "input": {
-                                                    "read": {
-                                                      "common": {
-                                                        "direct": {}
-                                                      },
-                                                      "baseSchema": {
-                                                        "names": [
-                                                          "o_orderkey",
-                                                          "o_custkey",
-                                                          "o_orderstatus",
-                                                          "o_totalprice",
-                                                          "o_orderdate",
-                                                          "o_orderpriority",
-                                                          "o_clerk",
-                                                          "o_shippriority",
-                                                          "o_comment"
-                                                        ],
-                                                        "struct": {
-                                                          "types": [
-                                                            {
-                                                              "i32": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i32": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "decimal": {
-                                                                "scale": 2,
-                                                                "precision": 15,
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "date": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "i32": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            },
-                                                            {
-                                                              "string": {
-                                                                "nullability": "NULLABILITY_REQUIRED"
-                                                              }
-                                                            }
-                                                          ],
-                                                          "nullability": "NULLABILITY_REQUIRED"
-                                                        }
-                                                      },
-                                                      "namedTable": {
-                                                        "names": [
-                                                          "orders"
-                                                        ]
-                                                      }
-                                                    }
-                                                  },
-                                                  "condition": {
-                                                    "scalarFunction": {
-                                                      "functionReference": 6,
-                                                      "outputType": {
-                                                        "bool": {
-                                                          "nullability": "NULLABILITY_NULLABLE"
-                                                        }
-                                                      },
-                                                      "arguments": [
-                                                        {
-                                                          "value": {
-                                                            "selection": {
-                                                              "directReference": {
-                                                                "structField": {
-                                                                  "field": 1
-                                                                }
-                                                              },
-                                                              "rootReference": {}
-                                                            }
-                                                          }
-                                                        },
-                                                        {
-                                                          "value": {
-                                                            "selection": {
-                                                              "directReference": {
-                                                                "structField": {}
-                                                              },
-                                                              "rootReference": {}
-                                                            }
-                                                          }
-                                                        }
-                                                      ]
-                                                    }
-                                                  }
-                                                }
-                                              }
                                             }
                                           }
-                                        }
+                                        ]
                                       }
-                                    ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "expressions": [
+                          {
+                            "scalarFunction": {
+                              "functionReference": 2,
+                              "outputType": {
+                                "string": {
+                                  "nullability": "NULLABILITY_NULLABLE"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "value": {
+                                    "selection": {
+                                      "directReference": {
+                                        "structField": {
+                                          "field": 4
+                                        }
+                                      },
+                                      "rootReference": {}
+                                    }
+                                  }
+                                },
+                                {
+                                  "value": {
+                                    "cast": {
+                                      "type": {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      "input": {
+                                        "literal": {
+                                          "i8": 0
+                                        }
+                                      },
+                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                    }
+                                  }
+                                },
+                                {
+                                  "value": {
+                                    "cast": {
+                                      "type": {
+                                        "i32": {
+                                          "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                      },
+                                      "input": {
+                                        "literal": {
+                                          "i8": 2
+                                        }
+                                      },
+                                      "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
+                                    }
                                   }
                                 }
-                              }
-                            ]
+                              ]
+                            }
+                          },
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {
+                                  "field": 5
+                                }
+                              },
+                              "rootReference": {}
+                            }
                           }
-                        }
+                        ]
                       }
                     },
-                    "expressions": [
+                    "groupings": [
                       {
-                        "scalarFunction": {
-                          "functionReference": 2,
+                        "groupingExpressions": [
+                          {
+                            "selection": {
+                              "directReference": {
+                                "structField": {}
+                              },
+                              "rootReference": {}
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "measures": [
+                      {
+                        "measure": {
+                          "functionReference": 7,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
                           "outputType": {
-                            "string": {
+                            "i64": {
+                              "nullability": "NULLABILITY_NULLABLE"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "measure": {
+                          "functionReference": 8,
+                          "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
+                          "outputType": {
+                            "decimal": {
+                              "scale": 2,
+                              "precision": 38,
                               "nullability": "NULLABILITY_NULLABLE"
                             }
                           },
@@ -742,114 +874,46 @@
                                 "selection": {
                                   "directReference": {
                                     "structField": {
-                                      "field": 4
+                                      "field": 1
                                     }
                                   },
                                   "rootReference": {}
                                 }
                               }
-                            },
-                            {
-                              "value": {
-                                "cast": {
-                                  "type": {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "input": {
-                                    "literal": {
-                                      "i8": 0
-                                    }
-                                  },
-                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                }
-                              }
-                            },
-                            {
-                              "value": {
-                                "cast": {
-                                  "type": {
-                                    "i32": {
-                                      "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                  },
-                                  "input": {
-                                    "literal": {
-                                      "i8": 2
-                                    }
-                                  },
-                                  "failureBehavior": "FAILURE_BEHAVIOR_THROW_EXCEPTION"
-                                }
-                              }
                             }
                           ]
-                        }
-                      },
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {
-                              "field": 5
-                            }
-                          },
-                          "rootReference": {}
                         }
                       }
                     ]
                   }
                 },
-                "groupings": [
+                "expressions": [
                   {
-                    "groupingExpressions": [
-                      {
-                        "selection": {
-                          "directReference": {
-                            "structField": {}
-                          },
-                          "rootReference": {}
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "measures": [
-                  {
-                    "measure": {
-                      "functionReference": 7,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "i64": {
-                          "nullability": "NULLABILITY_NULLABLE"
-                        }
-                      }
+                    "selection": {
+                      "directReference": {
+                        "structField": {}
+                      },
+                      "rootReference": {}
                     }
                   },
                   {
-                    "measure": {
-                      "functionReference": 8,
-                      "phase": "AGGREGATION_PHASE_INITIAL_TO_RESULT",
-                      "outputType": {
-                        "decimal": {
-                          "scale": 2,
-                          "precision": 38,
-                          "nullability": "NULLABILITY_NULLABLE"
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 1
                         }
                       },
-                      "arguments": [
-                        {
-                          "value": {
-                            "selection": {
-                              "directReference": {
-                                "structField": {
-                                  "field": 1
-                                }
-                              },
-                              "rootReference": {}
-                            }
-                          }
+                      "rootReference": {}
+                    }
+                  },
+                  {
+                    "selection": {
+                      "directReference": {
+                        "structField": {
+                          "field": 2
                         }
-                      ]
+                      },
+                      "rootReference": {}
                     }
                   }
                 ]

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -530,8 +530,8 @@ def test_groupby_multiple_keys(compiler):
     plan = translate(expr, compiler=compiler)
 
     # There should be one grouping with two separate expressions inside
-    assert len(plan.aggregate.groupings) == 1
-    assert len(plan.aggregate.groupings[0].grouping_expressions) == 2
+    assert len(plan.project.input.aggregate.groupings) == 1
+    assert len(plan.project.input.aggregate.groupings[0].grouping_expressions) == 2
 
 
 def test_join_chain_indexing_in_group_by(compiler):
@@ -556,7 +556,7 @@ def test_join_chain_indexing_in_group_by(compiler):
     # Check that the field index for the group_by key is correctly indexed
     assert (
         plan.relations[0]
-        .root.input.project.input.aggregate.groupings[0]
+        .root.input.project.input.project.input.aggregate.groupings[0]
         .grouping_expressions[0]
         .selection.direct_reference.struct_field.field
         == 5
@@ -567,7 +567,7 @@ def test_join_chain_indexing_in_group_by(compiler):
     # Check that the field index for the group_by key is correctly indexed
     assert (
         plan.relations[0]
-        .root.input.project.input.aggregate.groupings[0]
+        .root.input.project.input.project.input.aggregate.groupings[0]
         .grouping_expressions[0]
         .selection.direct_reference.struct_field.field
         == 3
@@ -579,7 +579,7 @@ def test_join_chain_indexing_in_group_by(compiler):
     # Check that the field index for the group_by key is correctly indexed
     assert (
         plan.relations[0]
-        .root.input.project.input.aggregate.groupings[0]
+        .root.input.project.input.project.input.aggregate.groupings[0]
         .grouping_expressions[0]
         .selection.direct_reference.struct_field.field
         == 7

--- a/ibis_substrait/tests/compiler/test_parity.py
+++ b/ibis_substrait/tests/compiler/test_parity.py
@@ -160,10 +160,7 @@ def test_left_join(consumer: str, request):
     "consumer",
     [
         "acero_consumer",
-        pytest.param(
-            "datafusion_consumer",
-            marks=[pytest.mark.xfail(Exception, reason="")],
-        ),
+        "datafusion_consumer",
     ],
 )
 def test_filter_groupby(consumer: str, request):
@@ -187,10 +184,7 @@ def test_filter_groupby(consumer: str, request):
                 pytest.mark.xfail(pa.ArrowNotImplementedError, reason="Unimplemented")
             ],
         ),
-        pytest.param(
-            "datafusion_consumer",
-            marks=[pytest.mark.xfail(Exception, reason="")],
-        ),
+        "datafusion_consumer",
     ],
 )
 def test_filter_groupby_count_distinct(consumer: str, request):


### PR DESCRIPTION
Currently plans generated by ibis-substrait containing an aggregate can't be run on datafusion. After a bit of a trial and error, I used datafusion's internal sql-to-substrait converter to see what kind of plans datafusion itself generates. Seems like datafusion always expects a projection node to follow after an aggregation node.

This PR introduces a dummy projection node that basically remaps aggregate output columns and does nothing. Targeting a specific consumer in a compiler sounds bad, but since it's an easy "fix" and still generates a valid plan for other consumers, I thought a temporary workaround was worth it.