### PR TITLE
feat: add outputNames hint to all Rels except joins

### DIFF
--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h01/tpc_h01.json
@@ -69,14 +69,91 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "l_returnflag",
+                  "l_linestatus",
+                  "sum_qty",
+                  "sum_base_price",
+                  "sum_disc_price",
+                  "sum_charge",
+                  "avg_qty",
+                  "avg_price",
+                  "avg_disc",
+                  "count_order"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "l_returnflag",
+                      "l_linestatus",
+                      "sum_qty",
+                      "sum_base_price",
+                      "sum_disc_price",
+                      "sum_charge",
+                      "avg_qty",
+                      "avg_price",
+                      "avg_disc",
+                      "count_order"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "l_orderkey",
+                          "l_partkey",
+                          "l_suppkey",
+                          "l_linenumber",
+                          "l_quantity",
+                          "l_extendedprice",
+                          "l_discount",
+                          "l_tax",
+                          "l_returnflag",
+                          "l_linestatus",
+                          "l_shipdate",
+                          "l_commitdate",
+                          "l_receiptdate",
+                          "l_shipinstruct",
+                          "l_shipmode",
+                          "l_comment"
+                        ]
+                      }
+                    },
                     "input": {
                       "read": {
                         "common": {
-                          "direct": {}
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment"
+                            ]
+                          }
                         },
                         "baseSchema": {
                           "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h02/tpc_h02.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h02/tpc_h02.json
@@ -52,8 +52,38 @@
       "root": {
         "input": {
           "fetch": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "s_acctbal",
+                  "s_name",
+                  "n_name",
+                  "p_partkey",
+                  "p_mfgr",
+                  "s_address",
+                  "s_phone",
+                  "s_comment"
+                ]
+              }
+            },
             "input": {
               "sort": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "s_acctbal",
+                      "s_name",
+                      "n_name",
+                      "p_partkey",
+                      "p_mfgr",
+                      "s_address",
+                      "s_phone",
+                      "s_comment"
+                    ]
+                  }
+                },
                 "input": {
                   "project": {
                     "common": {
@@ -68,10 +98,57 @@
                           34,
                           35
                         ]
+                      },
+                      "hint": {
+                        "outputNames": [
+                          "s_acctbal",
+                          "s_name",
+                          "n_name",
+                          "p_partkey",
+                          "p_mfgr",
+                          "s_address",
+                          "s_phone",
+                          "s_comment"
+                        ]
                       }
                     },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "p_partkey",
+                              "p_name",
+                              "p_mfgr",
+                              "p_brand",
+                              "p_type",
+                              "p_size",
+                              "p_container",
+                              "p_retailprice",
+                              "p_comment",
+                              "ps_partkey",
+                              "ps_suppkey",
+                              "ps_availqty",
+                              "ps_supplycost",
+                              "ps_comment",
+                              "s_suppkey",
+                              "s_name",
+                              "s_address",
+                              "s_nationkey",
+                              "s_phone",
+                              "s_acctbal",
+                              "s_comment",
+                              "n_nationkey",
+                              "n_name",
+                              "n_regionkey",
+                              "n_comment",
+                              "r_regionkey",
+                              "r_name",
+                              "r_comment"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -106,6 +183,38 @@
                                   54,
                                   55
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "p_partkey",
+                                  "p_name",
+                                  "p_mfgr",
+                                  "p_brand",
+                                  "p_type",
+                                  "p_size",
+                                  "p_container",
+                                  "p_retailprice",
+                                  "p_comment",
+                                  "ps_partkey",
+                                  "ps_suppkey",
+                                  "ps_availqty",
+                                  "ps_supplycost",
+                                  "ps_comment",
+                                  "s_suppkey",
+                                  "s_name",
+                                  "s_address",
+                                  "s_nationkey",
+                                  "s_phone",
+                                  "s_acctbal",
+                                  "s_comment",
+                                  "n_nationkey",
+                                  "n_name",
+                                  "n_regionkey",
+                                  "n_comment",
+                                  "r_regionkey",
+                                  "r_name",
+                                  "r_comment"
+                                ]
                               }
                             },
                             "input": {
@@ -119,7 +228,20 @@
                                             "left": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "p_partkey",
+                                                      "p_name",
+                                                      "p_mfgr",
+                                                      "p_brand",
+                                                      "p_type",
+                                                      "p_size",
+                                                      "p_container",
+                                                      "p_retailprice",
+                                                      "p_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -196,7 +318,16 @@
                                             "right": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "ps_partkey",
+                                                      "ps_suppkey",
+                                                      "ps_availqty",
+                                                      "ps_supplycost",
+                                                      "ps_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -286,7 +417,18 @@
                                         "right": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "s_suppkey",
+                                                  "s_name",
+                                                  "s_address",
+                                                  "s_nationkey",
+                                                  "s_phone",
+                                                  "s_acctbal",
+                                                  "s_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -390,7 +532,15 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "n_nationkey",
+                                              "n_name",
+                                              "n_regionkey",
+                                              "n_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -474,7 +624,14 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "r_regionkey",
+                                          "r_name",
+                                          "r_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -995,8 +1152,42 @@
                                             "scalar": {
                                               "input": {
                                                 "aggregate": {
+                                                  "common": {
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "Min(ps_supplycost)"
+                                                      ]
+                                                    }
+                                                  },
                                                   "input": {
                                                     "filter": {
+                                                      "common": {
+                                                        "direct": {},
+                                                        "hint": {
+                                                          "outputNames": [
+                                                            "ps_partkey",
+                                                            "ps_suppkey",
+                                                            "ps_availqty",
+                                                            "ps_supplycost",
+                                                            "ps_comment",
+                                                            "s_suppkey",
+                                                            "s_name",
+                                                            "s_address",
+                                                            "s_nationkey",
+                                                            "s_phone",
+                                                            "s_acctbal",
+                                                            "s_comment",
+                                                            "n_nationkey",
+                                                            "n_name",
+                                                            "n_regionkey",
+                                                            "n_comment",
+                                                            "r_regionkey",
+                                                            "r_name",
+                                                            "r_comment"
+                                                          ]
+                                                        }
+                                                      },
                                                       "input": {
                                                         "project": {
                                                           "common": {
@@ -1022,6 +1213,29 @@
                                                                 36,
                                                                 37
                                                               ]
+                                                            },
+                                                            "hint": {
+                                                              "outputNames": [
+                                                                "ps_partkey",
+                                                                "ps_suppkey",
+                                                                "ps_availqty",
+                                                                "ps_supplycost",
+                                                                "ps_comment",
+                                                                "s_suppkey",
+                                                                "s_name",
+                                                                "s_address",
+                                                                "s_nationkey",
+                                                                "s_phone",
+                                                                "s_acctbal",
+                                                                "s_comment",
+                                                                "n_nationkey",
+                                                                "n_name",
+                                                                "n_regionkey",
+                                                                "n_comment",
+                                                                "r_regionkey",
+                                                                "r_name",
+                                                                "r_comment"
+                                                              ]
                                                             }
                                                           },
                                                           "input": {
@@ -1033,7 +1247,16 @@
                                                                       "left": {
                                                                         "read": {
                                                                           "common": {
-                                                                            "direct": {}
+                                                                            "direct": {},
+                                                                            "hint": {
+                                                                              "outputNames": [
+                                                                                "ps_partkey",
+                                                                                "ps_suppkey",
+                                                                                "ps_availqty",
+                                                                                "ps_supplycost",
+                                                                                "ps_comment"
+                                                                              ]
+                                                                            }
                                                                           },
                                                                           "baseSchema": {
                                                                             "names": [
@@ -1086,7 +1309,18 @@
                                                                       "right": {
                                                                         "read": {
                                                                           "common": {
-                                                                            "direct": {}
+                                                                            "direct": {},
+                                                                            "hint": {
+                                                                              "outputNames": [
+                                                                                "s_suppkey",
+                                                                                "s_name",
+                                                                                "s_address",
+                                                                                "s_nationkey",
+                                                                                "s_phone",
+                                                                                "s_acctbal",
+                                                                                "s_comment"
+                                                                              ]
+                                                                            }
                                                                           },
                                                                           "baseSchema": {
                                                                             "names": [
@@ -1190,7 +1424,15 @@
                                                                   "right": {
                                                                     "read": {
                                                                       "common": {
-                                                                        "direct": {}
+                                                                        "direct": {},
+                                                                        "hint": {
+                                                                          "outputNames": [
+                                                                            "n_nationkey",
+                                                                            "n_name",
+                                                                            "n_regionkey",
+                                                                            "n_comment"
+                                                                          ]
+                                                                        }
                                                                       },
                                                                       "baseSchema": {
                                                                         "names": [
@@ -1274,7 +1516,14 @@
                                                               "right": {
                                                                 "read": {
                                                                   "common": {
-                                                                    "direct": {}
+                                                                    "direct": {},
+                                                                    "hint": {
+                                                                      "outputNames": [
+                                                                        "r_regionkey",
+                                                                        "r_name",
+                                                                        "r_comment"
+                                                                      ]
+                                                                    }
                                                                   },
                                                                   "baseSchema": {
                                                                     "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h03/tpc_h03.json
@@ -69,12 +69,85 @@
       "root": {
         "input": {
           "fetch": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "l_orderkey",
+                  "o_orderdate",
+                  "o_shippriority",
+                  "revenue"
+                ]
+              }
+            },
             "input": {
               "sort": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "l_orderkey",
+                      "o_orderdate",
+                      "o_shippriority",
+                      "revenue"
+                    ]
+                  }
+                },
                 "input": {
                   "aggregate": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "l_orderkey",
+                          "o_orderdate",
+                          "o_shippriority",
+                          "revenue"
+                        ]
+                      }
+                    },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "c_custkey",
+                              "c_name",
+                              "c_address",
+                              "c_nationkey",
+                              "c_phone",
+                              "c_acctbal",
+                              "c_mktsegment",
+                              "c_comment",
+                              "o_orderkey",
+                              "o_custkey",
+                              "o_orderstatus",
+                              "o_totalprice",
+                              "o_orderdate",
+                              "o_orderpriority",
+                              "o_clerk",
+                              "o_shippriority",
+                              "o_comment",
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -114,6 +187,43 @@
                                   64,
                                   65
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "c_custkey",
+                                  "c_name",
+                                  "c_address",
+                                  "c_nationkey",
+                                  "c_phone",
+                                  "c_acctbal",
+                                  "c_mktsegment",
+                                  "c_comment",
+                                  "o_orderkey",
+                                  "o_custkey",
+                                  "o_orderstatus",
+                                  "o_totalprice",
+                                  "o_orderdate",
+                                  "o_orderpriority",
+                                  "o_clerk",
+                                  "o_shippriority",
+                                  "o_comment",
+                                  "l_orderkey",
+                                  "l_partkey",
+                                  "l_suppkey",
+                                  "l_linenumber",
+                                  "l_quantity",
+                                  "l_extendedprice",
+                                  "l_discount",
+                                  "l_tax",
+                                  "l_returnflag",
+                                  "l_linestatus",
+                                  "l_shipdate",
+                                  "l_commitdate",
+                                  "l_receiptdate",
+                                  "l_shipinstruct",
+                                  "l_shipmode",
+                                  "l_comment"
+                                ]
                               }
                             },
                             "input": {
@@ -123,7 +233,19 @@
                                     "left": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "c_custkey",
+                                              "c_name",
+                                              "c_address",
+                                              "c_nationkey",
+                                              "c_phone",
+                                              "c_acctbal",
+                                              "c_mktsegment",
+                                              "c_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -194,7 +316,20 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "o_orderkey",
+                                              "o_custkey",
+                                              "o_orderstatus",
+                                              "o_totalprice",
+                                              "o_orderdate",
+                                              "o_orderpriority",
+                                              "o_clerk",
+                                              "o_shippriority",
+                                              "o_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -308,7 +443,27 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "l_orderkey",
+                                          "l_partkey",
+                                          "l_suppkey",
+                                          "l_linenumber",
+                                          "l_quantity",
+                                          "l_extendedprice",
+                                          "l_discount",
+                                          "l_tax",
+                                          "l_returnflag",
+                                          "l_linestatus",
+                                          "l_shipdate",
+                                          "l_commitdate",
+                                          "l_receiptdate",
+                                          "l_shipinstruct",
+                                          "l_shipmode",
+                                          "l_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h04/tpc_h04.json
@@ -55,14 +55,61 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "o_orderpriority",
+                  "order_count"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "o_orderpriority",
+                      "order_count"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "o_orderkey",
+                          "o_custkey",
+                          "o_orderstatus",
+                          "o_totalprice",
+                          "o_orderdate",
+                          "o_orderpriority",
+                          "o_clerk",
+                          "o_shippriority",
+                          "o_comment"
+                        ]
+                      }
+                    },
                     "input": {
                       "read": {
                         "common": {
-                          "direct": {}
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "o_orderkey",
+                              "o_custkey",
+                              "o_orderstatus",
+                              "o_totalprice",
+                              "o_orderdate",
+                              "o_orderpriority",
+                              "o_clerk",
+                              "o_shippriority",
+                              "o_comment"
+                            ]
+                          }
                         },
                         "baseSchema": {
                           "names": [
@@ -162,10 +209,53 @@
                                           "predicateOp": "PREDICATE_OP_EXISTS",
                                           "tuples": {
                                             "filter": {
+                                              "common": {
+                                                "direct": {},
+                                                "hint": {
+                                                  "outputNames": [
+                                                    "l_orderkey",
+                                                    "l_partkey",
+                                                    "l_suppkey",
+                                                    "l_linenumber",
+                                                    "l_quantity",
+                                                    "l_extendedprice",
+                                                    "l_discount",
+                                                    "l_tax",
+                                                    "l_returnflag",
+                                                    "l_linestatus",
+                                                    "l_shipdate",
+                                                    "l_commitdate",
+                                                    "l_receiptdate",
+                                                    "l_shipinstruct",
+                                                    "l_shipmode",
+                                                    "l_comment"
+                                                  ]
+                                                }
+                                              },
                                               "input": {
                                                 "read": {
                                                   "common": {
-                                                    "direct": {}
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "l_orderkey",
+                                                        "l_partkey",
+                                                        "l_suppkey",
+                                                        "l_linenumber",
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_tax",
+                                                        "l_returnflag",
+                                                        "l_linestatus",
+                                                        "l_shipdate",
+                                                        "l_commitdate",
+                                                        "l_receiptdate",
+                                                        "l_shipinstruct",
+                                                        "l_shipmode",
+                                                        "l_comment"
+                                                      ]
+                                                    }
                                                   },
                                                   "baseSchema": {
                                                     "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h05/tpc_h05.json
@@ -69,10 +69,82 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "n_name",
+                  "revenue"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "n_name",
+                      "revenue"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "c_custkey",
+                          "c_name",
+                          "c_address",
+                          "c_nationkey",
+                          "c_phone",
+                          "c_acctbal",
+                          "c_mktsegment",
+                          "c_comment",
+                          "o_orderkey",
+                          "o_custkey",
+                          "o_orderstatus",
+                          "o_totalprice",
+                          "o_orderdate",
+                          "o_orderpriority",
+                          "o_clerk",
+                          "o_shippriority",
+                          "o_comment",
+                          "l_orderkey",
+                          "l_partkey",
+                          "l_suppkey",
+                          "l_linenumber",
+                          "l_quantity",
+                          "l_extendedprice",
+                          "l_discount",
+                          "l_tax",
+                          "l_returnflag",
+                          "l_linestatus",
+                          "l_shipdate",
+                          "l_commitdate",
+                          "l_receiptdate",
+                          "l_shipinstruct",
+                          "l_shipmode",
+                          "l_comment",
+                          "s_suppkey",
+                          "s_name",
+                          "s_address",
+                          "s_nationkey",
+                          "s_phone",
+                          "s_acctbal",
+                          "s_comment",
+                          "n_nationkey",
+                          "n_name",
+                          "n_regionkey",
+                          "n_comment",
+                          "r_regionkey",
+                          "r_name",
+                          "r_comment"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -126,6 +198,57 @@
                               92,
                               93
                             ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "c_custkey",
+                              "c_name",
+                              "c_address",
+                              "c_nationkey",
+                              "c_phone",
+                              "c_acctbal",
+                              "c_mktsegment",
+                              "c_comment",
+                              "o_orderkey",
+                              "o_custkey",
+                              "o_orderstatus",
+                              "o_totalprice",
+                              "o_orderdate",
+                              "o_orderpriority",
+                              "o_clerk",
+                              "o_shippriority",
+                              "o_comment",
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment",
+                              "s_suppkey",
+                              "s_name",
+                              "s_address",
+                              "s_nationkey",
+                              "s_phone",
+                              "s_acctbal",
+                              "s_comment",
+                              "n_nationkey",
+                              "n_name",
+                              "n_regionkey",
+                              "n_comment",
+                              "r_regionkey",
+                              "r_name",
+                              "r_comment"
+                            ]
                           }
                         },
                         "input": {
@@ -141,7 +264,19 @@
                                             "left": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "c_custkey",
+                                                      "c_name",
+                                                      "c_address",
+                                                      "c_nationkey",
+                                                      "c_phone",
+                                                      "c_acctbal",
+                                                      "c_mktsegment",
+                                                      "c_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -212,7 +347,20 @@
                                             "right": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "o_orderkey",
+                                                      "o_custkey",
+                                                      "o_orderstatus",
+                                                      "o_totalprice",
+                                                      "o_orderdate",
+                                                      "o_orderpriority",
+                                                      "o_clerk",
+                                                      "o_shippriority",
+                                                      "o_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -326,7 +474,27 @@
                                         "right": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "l_orderkey",
+                                                  "l_partkey",
+                                                  "l_suppkey",
+                                                  "l_linenumber",
+                                                  "l_quantity",
+                                                  "l_extendedprice",
+                                                  "l_discount",
+                                                  "l_tax",
+                                                  "l_returnflag",
+                                                  "l_linestatus",
+                                                  "l_shipdate",
+                                                  "l_commitdate",
+                                                  "l_receiptdate",
+                                                  "l_shipinstruct",
+                                                  "l_shipmode",
+                                                  "l_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -490,7 +658,18 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "s_suppkey",
+                                              "s_name",
+                                              "s_address",
+                                              "s_nationkey",
+                                              "s_phone",
+                                              "s_acctbal",
+                                              "s_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -594,7 +773,15 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "n_nationkey",
+                                          "n_name",
+                                          "n_regionkey",
+                                          "n_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -730,7 +917,14 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "r_regionkey",
+                                      "r_name",
+                                      "r_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h06/tpc_h06.json
@@ -62,12 +62,63 @@
       "root": {
         "input": {
           "aggregate": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "revenue"
+                ]
+              }
+            },
             "input": {
               "filter": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "l_orderkey",
+                      "l_partkey",
+                      "l_suppkey",
+                      "l_linenumber",
+                      "l_quantity",
+                      "l_extendedprice",
+                      "l_discount",
+                      "l_tax",
+                      "l_returnflag",
+                      "l_linestatus",
+                      "l_shipdate",
+                      "l_commitdate",
+                      "l_receiptdate",
+                      "l_shipinstruct",
+                      "l_shipmode",
+                      "l_comment"
+                    ]
+                  }
+                },
                 "input": {
                   "read": {
                     "common": {
-                      "direct": {}
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "l_orderkey",
+                          "l_partkey",
+                          "l_suppkey",
+                          "l_linenumber",
+                          "l_quantity",
+                          "l_extendedprice",
+                          "l_discount",
+                          "l_tax",
+                          "l_returnflag",
+                          "l_linestatus",
+                          "l_shipdate",
+                          "l_commitdate",
+                          "l_receiptdate",
+                          "l_shipinstruct",
+                          "l_shipmode",
+                          "l_comment"
+                        ]
+                      }
                     },
                     "baseSchema": {
                       "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h07/tpc_h07.json
@@ -80,10 +80,46 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "supp_nation",
+                  "cust_nation",
+                  "l_year",
+                  "revenue"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "supp_nation",
+                      "cust_nation",
+                      "l_year",
+                      "revenue"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "supp_nation",
+                          "cust_nation",
+                          "l_shipdate",
+                          "l_extendedprice",
+                          "l_discount",
+                          "l_year",
+                          "volume"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -96,6 +132,17 @@
                               52,
                               53,
                               54
+                            ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "supp_nation",
+                              "cust_nation",
+                              "l_shipdate",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_year",
+                              "volume"
                             ]
                           }
                         },
@@ -112,7 +159,18 @@
                                             "left": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "s_suppkey",
+                                                      "s_name",
+                                                      "s_address",
+                                                      "s_nationkey",
+                                                      "s_phone",
+                                                      "s_acctbal",
+                                                      "s_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -177,7 +235,27 @@
                                             "right": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "l_orderkey",
+                                                      "l_partkey",
+                                                      "l_suppkey",
+                                                      "l_linenumber",
+                                                      "l_quantity",
+                                                      "l_extendedprice",
+                                                      "l_discount",
+                                                      "l_tax",
+                                                      "l_returnflag",
+                                                      "l_linestatus",
+                                                      "l_shipdate",
+                                                      "l_commitdate",
+                                                      "l_receiptdate",
+                                                      "l_shipinstruct",
+                                                      "l_shipmode",
+                                                      "l_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -339,7 +417,20 @@
                                         "right": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "o_orderkey",
+                                                  "o_custkey",
+                                                  "o_orderstatus",
+                                                  "o_totalprice",
+                                                  "o_orderdate",
+                                                  "o_orderpriority",
+                                                  "o_clerk",
+                                                  "o_shippriority",
+                                                  "o_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -455,7 +546,19 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "c_custkey",
+                                              "c_name",
+                                              "c_address",
+                                              "c_nationkey",
+                                              "c_phone",
+                                              "c_acctbal",
+                                              "c_mktsegment",
+                                              "c_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -565,7 +668,15 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "n_nationkey",
+                                          "n_name",
+                                          "n_regionkey",
+                                          "n_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -649,7 +760,15 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "n_nationkey",
+                                      "n_name",
+                                      "n_regionkey",
+                                      "n_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h08/tpc_h08.json
@@ -80,6 +80,15 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "o_year",
+                  "mkt_share"
+                ]
+              }
+            },
             "input": {
               "project": {
                 "common": {
@@ -87,6 +96,12 @@
                     "outputMapping": [
                       4,
                       5
+                    ]
+                  },
+                  "hint": {
+                    "outputNames": [
+                      "o_year",
+                      "mkt_share"
                     ]
                   }
                 },
@@ -100,10 +115,28 @@
                           5,
                           6
                         ]
+                      },
+                      "hint": {
+                        "outputNames": [
+                          "o_year",
+                          "nation_volume_sum",
+                          "volume_sum",
+                          "mkt_share"
+                        ]
                       }
                     },
                     "input": {
                       "aggregate": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "o_year",
+                              "nation_volume_sum",
+                              "volume_sum"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -117,10 +150,34 @@
                                   11,
                                   12
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "o_year",
+                                  "volume",
+                                  "nation",
+                                  "r_name",
+                                  "o_orderdate",
+                                  "p_type",
+                                  "nation_volume"
+                                ]
                               }
                             },
                             "input": {
                               "filter": {
+                                "common": {
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "o_year",
+                                      "volume",
+                                      "nation",
+                                      "r_name",
+                                      "o_orderdate",
+                                      "p_type"
+                                    ]
+                                  }
+                                },
                                 "input": {
                                   "project": {
                                     "common": {
@@ -132,6 +189,16 @@
                                           63,
                                           64,
                                           65
+                                        ]
+                                      },
+                                      "hint": {
+                                        "outputNames": [
+                                          "o_year",
+                                          "volume",
+                                          "nation",
+                                          "r_name",
+                                          "o_orderdate",
+                                          "p_type"
                                         ]
                                       }
                                     },
@@ -152,7 +219,20 @@
                                                                 "left": {
                                                                   "read": {
                                                                     "common": {
-                                                                      "direct": {}
+                                                                      "direct": {},
+                                                                      "hint": {
+                                                                        "outputNames": [
+                                                                          "p_partkey",
+                                                                          "p_name",
+                                                                          "p_mfgr",
+                                                                          "p_brand",
+                                                                          "p_type",
+                                                                          "p_size",
+                                                                          "p_container",
+                                                                          "p_retailprice",
+                                                                          "p_comment"
+                                                                        ]
+                                                                      }
                                                                     },
                                                                     "baseSchema": {
                                                                       "names": [
@@ -229,7 +309,27 @@
                                                                 "right": {
                                                                   "read": {
                                                                     "common": {
-                                                                      "direct": {}
+                                                                      "direct": {},
+                                                                      "hint": {
+                                                                        "outputNames": [
+                                                                          "l_orderkey",
+                                                                          "l_partkey",
+                                                                          "l_suppkey",
+                                                                          "l_linenumber",
+                                                                          "l_quantity",
+                                                                          "l_extendedprice",
+                                                                          "l_discount",
+                                                                          "l_tax",
+                                                                          "l_returnflag",
+                                                                          "l_linestatus",
+                                                                          "l_shipdate",
+                                                                          "l_commitdate",
+                                                                          "l_receiptdate",
+                                                                          "l_shipinstruct",
+                                                                          "l_shipmode",
+                                                                          "l_comment"
+                                                                        ]
+                                                                      }
                                                                     },
                                                                     "baseSchema": {
                                                                       "names": [
@@ -391,7 +491,18 @@
                                                             "right": {
                                                               "read": {
                                                                 "common": {
-                                                                  "direct": {}
+                                                                  "direct": {},
+                                                                  "hint": {
+                                                                    "outputNames": [
+                                                                      "s_suppkey",
+                                                                      "s_name",
+                                                                      "s_address",
+                                                                      "s_nationkey",
+                                                                      "s_phone",
+                                                                      "s_acctbal",
+                                                                      "s_comment"
+                                                                    ]
+                                                                  }
                                                                 },
                                                                 "baseSchema": {
                                                                   "names": [
@@ -495,7 +606,20 @@
                                                         "right": {
                                                           "read": {
                                                             "common": {
-                                                              "direct": {}
+                                                              "direct": {},
+                                                              "hint": {
+                                                                "outputNames": [
+                                                                  "o_orderkey",
+                                                                  "o_custkey",
+                                                                  "o_orderstatus",
+                                                                  "o_totalprice",
+                                                                  "o_orderdate",
+                                                                  "o_orderpriority",
+                                                                  "o_clerk",
+                                                                  "o_shippriority",
+                                                                  "o_comment"
+                                                                ]
+                                                              }
                                                             },
                                                             "baseSchema": {
                                                               "names": [
@@ -611,7 +735,19 @@
                                                     "right": {
                                                       "read": {
                                                         "common": {
-                                                          "direct": {}
+                                                          "direct": {},
+                                                          "hint": {
+                                                            "outputNames": [
+                                                              "c_custkey",
+                                                              "c_name",
+                                                              "c_address",
+                                                              "c_nationkey",
+                                                              "c_phone",
+                                                              "c_acctbal",
+                                                              "c_mktsegment",
+                                                              "c_comment"
+                                                            ]
+                                                          }
                                                         },
                                                         "baseSchema": {
                                                           "names": [
@@ -721,7 +857,15 @@
                                                 "right": {
                                                   "read": {
                                                     "common": {
-                                                      "direct": {}
+                                                      "direct": {},
+                                                      "hint": {
+                                                        "outputNames": [
+                                                          "n_nationkey",
+                                                          "n_name",
+                                                          "n_regionkey",
+                                                          "n_comment"
+                                                        ]
+                                                      }
                                                     },
                                                     "baseSchema": {
                                                       "names": [
@@ -805,7 +949,14 @@
                                             "right": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "r_regionkey",
+                                                      "r_name",
+                                                      "r_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -883,7 +1034,15 @@
                                         "right": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "n_nationkey",
+                                                  "n_name",
+                                                  "n_regionkey",
+                                                  "n_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h09/tpc_h09.json
@@ -77,10 +77,41 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "nation",
+                  "o_year",
+                  "sum_profit"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "nation",
+                      "o_year",
+                      "sum_profit"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "amount",
+                          "o_year",
+                          "nation",
+                          "p_name"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -90,6 +121,14 @@
                               51,
                               52,
                               53
+                            ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "amount",
+                              "o_year",
+                              "nation",
+                              "p_name"
                             ]
                           }
                         },
@@ -106,7 +145,27 @@
                                             "left": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "l_orderkey",
+                                                      "l_partkey",
+                                                      "l_suppkey",
+                                                      "l_linenumber",
+                                                      "l_quantity",
+                                                      "l_extendedprice",
+                                                      "l_discount",
+                                                      "l_tax",
+                                                      "l_returnflag",
+                                                      "l_linestatus",
+                                                      "l_shipdate",
+                                                      "l_commitdate",
+                                                      "l_receiptdate",
+                                                      "l_shipinstruct",
+                                                      "l_shipmode",
+                                                      "l_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -231,7 +290,18 @@
                                             "right": {
                                               "read": {
                                                 "common": {
-                                                  "direct": {}
+                                                  "direct": {},
+                                                  "hint": {
+                                                    "outputNames": [
+                                                      "s_suppkey",
+                                                      "s_name",
+                                                      "s_address",
+                                                      "s_nationkey",
+                                                      "s_phone",
+                                                      "s_acctbal",
+                                                      "s_comment"
+                                                    ]
+                                                  }
                                                 },
                                                 "baseSchema": {
                                                   "names": [
@@ -335,7 +405,16 @@
                                         "right": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "ps_partkey",
+                                                  "ps_suppkey",
+                                                  "ps_availqty",
+                                                  "ps_supplycost",
+                                                  "ps_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -479,7 +558,20 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "p_partkey",
+                                              "p_name",
+                                              "p_mfgr",
+                                              "p_brand",
+                                              "p_type",
+                                              "p_size",
+                                              "p_container",
+                                              "p_retailprice",
+                                              "p_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -595,7 +687,20 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "o_orderkey",
+                                          "o_custkey",
+                                          "o_orderstatus",
+                                          "o_totalprice",
+                                          "o_orderdate",
+                                          "o_orderpriority",
+                                          "o_clerk",
+                                          "o_shippriority",
+                                          "o_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -709,7 +814,15 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "n_nationkey",
+                                      "n_name",
+                                      "n_regionkey",
+                                      "n_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h10/tpc_h10.json
@@ -69,12 +69,101 @@
       "root": {
         "input": {
           "fetch": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "c_custkey",
+                  "c_name",
+                  "c_acctbal",
+                  "c_phone",
+                  "n_name",
+                  "c_address",
+                  "c_comment",
+                  "revenue"
+                ]
+              }
+            },
             "input": {
               "sort": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "c_custkey",
+                      "c_name",
+                      "c_acctbal",
+                      "c_phone",
+                      "n_name",
+                      "c_address",
+                      "c_comment",
+                      "revenue"
+                    ]
+                  }
+                },
                 "input": {
                   "aggregate": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "c_custkey",
+                          "c_name",
+                          "c_acctbal",
+                          "c_phone",
+                          "n_name",
+                          "c_address",
+                          "c_comment",
+                          "revenue"
+                        ]
+                      }
+                    },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "c_custkey",
+                              "c_name",
+                              "c_address",
+                              "c_nationkey",
+                              "c_phone",
+                              "c_acctbal",
+                              "c_mktsegment",
+                              "c_comment",
+                              "o_orderkey",
+                              "o_custkey",
+                              "o_orderstatus",
+                              "o_totalprice",
+                              "o_orderdate",
+                              "o_orderpriority",
+                              "o_clerk",
+                              "o_shippriority",
+                              "o_comment",
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment",
+                              "n_nationkey",
+                              "n_name",
+                              "n_regionkey",
+                              "n_comment"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -118,6 +207,47 @@
                                   72,
                                   73
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "c_custkey",
+                                  "c_name",
+                                  "c_address",
+                                  "c_nationkey",
+                                  "c_phone",
+                                  "c_acctbal",
+                                  "c_mktsegment",
+                                  "c_comment",
+                                  "o_orderkey",
+                                  "o_custkey",
+                                  "o_orderstatus",
+                                  "o_totalprice",
+                                  "o_orderdate",
+                                  "o_orderpriority",
+                                  "o_clerk",
+                                  "o_shippriority",
+                                  "o_comment",
+                                  "l_orderkey",
+                                  "l_partkey",
+                                  "l_suppkey",
+                                  "l_linenumber",
+                                  "l_quantity",
+                                  "l_extendedprice",
+                                  "l_discount",
+                                  "l_tax",
+                                  "l_returnflag",
+                                  "l_linestatus",
+                                  "l_shipdate",
+                                  "l_commitdate",
+                                  "l_receiptdate",
+                                  "l_shipinstruct",
+                                  "l_shipmode",
+                                  "l_comment",
+                                  "n_nationkey",
+                                  "n_name",
+                                  "n_regionkey",
+                                  "n_comment"
+                                ]
                               }
                             },
                             "input": {
@@ -129,7 +259,19 @@
                                         "left": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "c_custkey",
+                                                  "c_name",
+                                                  "c_address",
+                                                  "c_nationkey",
+                                                  "c_phone",
+                                                  "c_acctbal",
+                                                  "c_mktsegment",
+                                                  "c_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -200,7 +342,20 @@
                                         "right": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "o_orderkey",
+                                                  "o_custkey",
+                                                  "o_orderstatus",
+                                                  "o_totalprice",
+                                                  "o_orderdate",
+                                                  "o_orderpriority",
+                                                  "o_clerk",
+                                                  "o_shippriority",
+                                                  "o_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -314,7 +469,27 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "l_orderkey",
+                                              "l_partkey",
+                                              "l_suppkey",
+                                              "l_linenumber",
+                                              "l_quantity",
+                                              "l_extendedprice",
+                                              "l_discount",
+                                              "l_tax",
+                                              "l_returnflag",
+                                              "l_linestatus",
+                                              "l_shipdate",
+                                              "l_commitdate",
+                                              "l_receiptdate",
+                                              "l_shipinstruct",
+                                              "l_shipmode",
+                                              "l_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -478,7 +653,15 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "n_nationkey",
+                                          "n_name",
+                                          "n_regionkey",
+                                          "n_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h11/tpc_h11.json
@@ -44,12 +44,62 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "ps_partkey",
+                  "value"
+                ]
+              }
+            },
             "input": {
               "filter": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "ps_partkey",
+                      "value"
+                    ]
+                  }
+                },
                 "input": {
                   "aggregate": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "ps_partkey",
+                          "value"
+                        ]
+                      }
+                    },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "ps_partkey",
+                              "ps_suppkey",
+                              "ps_availqty",
+                              "ps_supplycost",
+                              "ps_comment",
+                              "s_suppkey",
+                              "s_name",
+                              "s_address",
+                              "s_nationkey",
+                              "s_phone",
+                              "s_acctbal",
+                              "s_comment",
+                              "n_nationkey",
+                              "n_name",
+                              "n_regionkey",
+                              "n_comment"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -72,6 +122,26 @@
                                   30,
                                   31
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "ps_partkey",
+                                  "ps_suppkey",
+                                  "ps_availqty",
+                                  "ps_supplycost",
+                                  "ps_comment",
+                                  "s_suppkey",
+                                  "s_name",
+                                  "s_address",
+                                  "s_nationkey",
+                                  "s_phone",
+                                  "s_acctbal",
+                                  "s_comment",
+                                  "n_nationkey",
+                                  "n_name",
+                                  "n_regionkey",
+                                  "n_comment"
+                                ]
                               }
                             },
                             "input": {
@@ -81,7 +151,16 @@
                                     "left": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "ps_partkey",
+                                              "ps_suppkey",
+                                              "ps_availqty",
+                                              "ps_supplycost",
+                                              "ps_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -134,7 +213,18 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "s_suppkey",
+                                              "s_name",
+                                              "s_address",
+                                              "s_nationkey",
+                                              "s_phone",
+                                              "s_acctbal",
+                                              "s_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -238,7 +328,15 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "n_nationkey",
+                                          "n_name",
+                                          "n_regionkey",
+                                          "n_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -638,8 +736,39 @@
                                     "scalar": {
                                       "input": {
                                         "aggregate": {
+                                          "common": {
+                                            "direct": {},
+                                            "hint": {
+                                              "outputNames": [
+                                                "Sum(Multiply(ps_supplycost, ps_availqty))"
+                                              ]
+                                            }
+                                          },
                                           "input": {
                                             "filter": {
+                                              "common": {
+                                                "direct": {},
+                                                "hint": {
+                                                  "outputNames": [
+                                                    "ps_partkey",
+                                                    "ps_suppkey",
+                                                    "ps_availqty",
+                                                    "ps_supplycost",
+                                                    "ps_comment",
+                                                    "s_suppkey",
+                                                    "s_name",
+                                                    "s_address",
+                                                    "s_nationkey",
+                                                    "s_phone",
+                                                    "s_acctbal",
+                                                    "s_comment",
+                                                    "n_nationkey",
+                                                    "n_name",
+                                                    "n_regionkey",
+                                                    "n_comment"
+                                                  ]
+                                                }
+                                              },
                                               "input": {
                                                 "project": {
                                                   "common": {
@@ -662,6 +791,26 @@
                                                         30,
                                                         31
                                                       ]
+                                                    },
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "ps_partkey",
+                                                        "ps_suppkey",
+                                                        "ps_availqty",
+                                                        "ps_supplycost",
+                                                        "ps_comment",
+                                                        "s_suppkey",
+                                                        "s_name",
+                                                        "s_address",
+                                                        "s_nationkey",
+                                                        "s_phone",
+                                                        "s_acctbal",
+                                                        "s_comment",
+                                                        "n_nationkey",
+                                                        "n_name",
+                                                        "n_regionkey",
+                                                        "n_comment"
+                                                      ]
                                                     }
                                                   },
                                                   "input": {
@@ -671,7 +820,16 @@
                                                           "left": {
                                                             "read": {
                                                               "common": {
-                                                                "direct": {}
+                                                                "direct": {},
+                                                                "hint": {
+                                                                  "outputNames": [
+                                                                    "ps_partkey",
+                                                                    "ps_suppkey",
+                                                                    "ps_availqty",
+                                                                    "ps_supplycost",
+                                                                    "ps_comment"
+                                                                  ]
+                                                                }
                                                               },
                                                               "baseSchema": {
                                                                 "names": [
@@ -724,7 +882,18 @@
                                                           "right": {
                                                             "read": {
                                                               "common": {
-                                                                "direct": {}
+                                                                "direct": {},
+                                                                "hint": {
+                                                                  "outputNames": [
+                                                                    "s_suppkey",
+                                                                    "s_name",
+                                                                    "s_address",
+                                                                    "s_nationkey",
+                                                                    "s_phone",
+                                                                    "s_acctbal",
+                                                                    "s_comment"
+                                                                  ]
+                                                                }
                                                               },
                                                               "baseSchema": {
                                                                 "names": [
@@ -828,7 +997,15 @@
                                                       "right": {
                                                         "read": {
                                                           "common": {
-                                                            "direct": {}
+                                                            "direct": {},
+                                                            "hint": {
+                                                              "outputNames": [
+                                                                "n_nationkey",
+                                                                "n_name",
+                                                                "n_regionkey",
+                                                                "n_comment"
+                                                              ]
+                                                            }
                                                           },
                                                           "baseSchema": {
                                                             "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h12/tpc_h12.json
@@ -55,10 +55,62 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "l_shipmode",
+                  "high_line_count",
+                  "low_line_count"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "l_shipmode",
+                      "high_line_count",
+                      "low_line_count"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "o_orderkey",
+                          "o_custkey",
+                          "o_orderstatus",
+                          "o_totalprice",
+                          "o_orderdate",
+                          "o_orderpriority",
+                          "o_clerk",
+                          "o_shippriority",
+                          "o_comment",
+                          "l_orderkey",
+                          "l_partkey",
+                          "l_suppkey",
+                          "l_linenumber",
+                          "l_quantity",
+                          "l_extendedprice",
+                          "l_discount",
+                          "l_tax",
+                          "l_returnflag",
+                          "l_linestatus",
+                          "l_shipdate",
+                          "l_commitdate",
+                          "l_receiptdate",
+                          "l_shipinstruct",
+                          "l_shipmode",
+                          "l_comment"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -90,6 +142,35 @@
                               48,
                               49
                             ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "o_orderkey",
+                              "o_custkey",
+                              "o_orderstatus",
+                              "o_totalprice",
+                              "o_orderdate",
+                              "o_orderpriority",
+                              "o_clerk",
+                              "o_shippriority",
+                              "o_comment",
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment"
+                            ]
                           }
                         },
                         "input": {
@@ -97,7 +178,20 @@
                             "left": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "o_orderkey",
+                                      "o_custkey",
+                                      "o_orderstatus",
+                                      "o_totalprice",
+                                      "o_orderdate",
+                                      "o_orderpriority",
+                                      "o_clerk",
+                                      "o_shippriority",
+                                      "o_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -174,7 +268,27 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "l_orderkey",
+                                      "l_partkey",
+                                      "l_suppkey",
+                                      "l_linenumber",
+                                      "l_quantity",
+                                      "l_extendedprice",
+                                      "l_discount",
+                                      "l_tax",
+                                      "l_returnflag",
+                                      "l_linestatus",
+                                      "l_shipdate",
+                                      "l_commitdate",
+                                      "l_receiptdate",
+                                      "l_shipinstruct",
+                                      "l_shipmode",
+                                      "l_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h13/tpc_h13.json
@@ -59,10 +59,37 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "c_count",
+                  "custdist"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "c_count",
+                      "custdist"
+                    ]
+                  }
+                },
                 "input": {
                   "aggregate": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "c_custkey",
+                          "c_count"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -86,6 +113,27 @@
                               32,
                               33
                             ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "c_custkey",
+                              "c_name",
+                              "c_address",
+                              "c_nationkey",
+                              "c_phone",
+                              "c_acctbal",
+                              "c_mktsegment",
+                              "c_comment",
+                              "o_orderkey",
+                              "o_custkey",
+                              "o_orderstatus",
+                              "o_totalprice",
+                              "o_orderdate",
+                              "o_orderpriority",
+                              "o_clerk",
+                              "o_shippriority",
+                              "o_comment"
+                            ]
                           }
                         },
                         "input": {
@@ -93,7 +141,19 @@
                             "left": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "c_custkey",
+                                      "c_name",
+                                      "c_address",
+                                      "c_nationkey",
+                                      "c_phone",
+                                      "c_acctbal",
+                                      "c_mktsegment",
+                                      "c_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -164,7 +224,20 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "o_orderkey",
+                                      "o_custkey",
+                                      "o_orderstatus",
+                                      "o_totalprice",
+                                      "o_orderdate",
+                                      "o_orderpriority",
+                                      "o_clerk",
+                                      "o_shippriority",
+                                      "o_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h14/tpc_h14.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h14/tpc_h14.json
@@ -92,6 +92,11 @@
                 "outputMapping": [
                   3
                 ]
+              },
+              "hint": {
+                "outputNames": [
+                  "promo_revenue"
+                ]
               }
             },
             "input": {
@@ -103,12 +108,60 @@
                       3,
                       4
                     ]
+                  },
+                  "hint": {
+                    "outputNames": [
+                      "promo_revenue_sum",
+                      "revenue_sum",
+                      "promo_revenue"
+                    ]
                   }
                 },
                 "input": {
                   "aggregate": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "promo_revenue_sum",
+                          "revenue_sum"
+                        ]
+                      }
+                    },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment",
+                              "p_partkey",
+                              "p_name",
+                              "p_mfgr",
+                              "p_brand",
+                              "p_type",
+                              "p_size",
+                              "p_container",
+                              "p_retailprice",
+                              "p_comment"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -140,6 +193,35 @@
                                   48,
                                   49
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "l_orderkey",
+                                  "l_partkey",
+                                  "l_suppkey",
+                                  "l_linenumber",
+                                  "l_quantity",
+                                  "l_extendedprice",
+                                  "l_discount",
+                                  "l_tax",
+                                  "l_returnflag",
+                                  "l_linestatus",
+                                  "l_shipdate",
+                                  "l_commitdate",
+                                  "l_receiptdate",
+                                  "l_shipinstruct",
+                                  "l_shipmode",
+                                  "l_comment",
+                                  "p_partkey",
+                                  "p_name",
+                                  "p_mfgr",
+                                  "p_brand",
+                                  "p_type",
+                                  "p_size",
+                                  "p_container",
+                                  "p_retailprice",
+                                  "p_comment"
+                                ]
                               }
                             },
                             "input": {
@@ -147,7 +229,27 @@
                                 "left": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "l_orderkey",
+                                          "l_partkey",
+                                          "l_suppkey",
+                                          "l_linenumber",
+                                          "l_quantity",
+                                          "l_extendedprice",
+                                          "l_discount",
+                                          "l_tax",
+                                          "l_returnflag",
+                                          "l_linestatus",
+                                          "l_shipdate",
+                                          "l_commitdate",
+                                          "l_receiptdate",
+                                          "l_shipinstruct",
+                                          "l_shipmode",
+                                          "l_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -272,7 +374,20 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "p_partkey",
+                                          "p_name",
+                                          "p_mfgr",
+                                          "p_brand",
+                                          "p_type",
+                                          "p_size",
+                                          "p_container",
+                                          "p_retailprice",
+                                          "p_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h15/tpc_h15.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h15/tpc_h15.json
@@ -85,12 +85,53 @@
                   12,
                   13
                 ]
+              },
+              "hint": {
+                "outputNames": [
+                  "s_suppkey",
+                  "s_name",
+                  "s_address",
+                  "s_phone",
+                  "total_revenue"
+                ]
               }
             },
             "input": {
               "sort": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "s_suppkey",
+                      "s_name",
+                      "s_address",
+                      "s_nationkey",
+                      "s_phone",
+                      "s_acctbal",
+                      "s_comment",
+                      "l_suppkey",
+                      "total_revenue"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "s_suppkey",
+                          "s_name",
+                          "s_address",
+                          "s_nationkey",
+                          "s_phone",
+                          "s_acctbal",
+                          "s_comment",
+                          "l_suppkey",
+                          "total_revenue"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -106,6 +147,19 @@
                               16,
                               17
                             ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "s_suppkey",
+                              "s_name",
+                              "s_address",
+                              "s_nationkey",
+                              "s_phone",
+                              "s_acctbal",
+                              "s_comment",
+                              "l_suppkey",
+                              "total_revenue"
+                            ]
                           }
                         },
                         "input": {
@@ -113,7 +167,18 @@
                             "left": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "s_suppkey",
+                                      "s_name",
+                                      "s_address",
+                                      "s_nationkey",
+                                      "s_phone",
+                                      "s_acctbal",
+                                      "s_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -177,12 +242,64 @@
                             },
                             "right": {
                               "aggregate": {
+                                "common": {
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "l_suppkey",
+                                      "total_revenue"
+                                    ]
+                                  }
+                                },
                                 "input": {
                                   "filter": {
+                                    "common": {
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "l_orderkey",
+                                          "l_partkey",
+                                          "l_suppkey",
+                                          "l_linenumber",
+                                          "l_quantity",
+                                          "l_extendedprice",
+                                          "l_discount",
+                                          "l_tax",
+                                          "l_returnflag",
+                                          "l_linestatus",
+                                          "l_shipdate",
+                                          "l_commitdate",
+                                          "l_receiptdate",
+                                          "l_shipinstruct",
+                                          "l_shipmode",
+                                          "l_comment"
+                                        ]
+                                      }
+                                    },
                                     "input": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "l_orderkey",
+                                              "l_partkey",
+                                              "l_suppkey",
+                                              "l_linenumber",
+                                              "l_quantity",
+                                              "l_extendedprice",
+                                              "l_discount",
+                                              "l_tax",
+                                              "l_returnflag",
+                                              "l_linestatus",
+                                              "l_shipdate",
+                                              "l_commitdate",
+                                              "l_receiptdate",
+                                              "l_shipinstruct",
+                                              "l_shipmode",
+                                              "l_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -650,6 +767,14 @@
                                 "scalar": {
                                   "input": {
                                     "aggregate": {
+                                      "common": {
+                                        "direct": {},
+                                        "hint": {
+                                          "outputNames": [
+                                            "Max(total_revenue)"
+                                          ]
+                                        }
+                                      },
                                       "input": {
                                         "project": {
                                           "common": {
@@ -665,6 +790,19 @@
                                                 16,
                                                 17
                                               ]
+                                            },
+                                            "hint": {
+                                              "outputNames": [
+                                                "s_suppkey",
+                                                "s_name",
+                                                "s_address",
+                                                "s_nationkey",
+                                                "s_phone",
+                                                "s_acctbal",
+                                                "s_comment",
+                                                "l_suppkey",
+                                                "total_revenue"
+                                              ]
                                             }
                                           },
                                           "input": {
@@ -672,7 +810,18 @@
                                               "left": {
                                                 "read": {
                                                   "common": {
-                                                    "direct": {}
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "s_suppkey",
+                                                        "s_name",
+                                                        "s_address",
+                                                        "s_nationkey",
+                                                        "s_phone",
+                                                        "s_acctbal",
+                                                        "s_comment"
+                                                      ]
+                                                    }
                                                   },
                                                   "baseSchema": {
                                                     "names": [
@@ -736,12 +885,64 @@
                                               },
                                               "right": {
                                                 "aggregate": {
+                                                  "common": {
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "l_suppkey",
+                                                        "total_revenue"
+                                                      ]
+                                                    }
+                                                  },
                                                   "input": {
                                                     "filter": {
+                                                      "common": {
+                                                        "direct": {},
+                                                        "hint": {
+                                                          "outputNames": [
+                                                            "l_orderkey",
+                                                            "l_partkey",
+                                                            "l_suppkey",
+                                                            "l_linenumber",
+                                                            "l_quantity",
+                                                            "l_extendedprice",
+                                                            "l_discount",
+                                                            "l_tax",
+                                                            "l_returnflag",
+                                                            "l_linestatus",
+                                                            "l_shipdate",
+                                                            "l_commitdate",
+                                                            "l_receiptdate",
+                                                            "l_shipinstruct",
+                                                            "l_shipmode",
+                                                            "l_comment"
+                                                          ]
+                                                        }
+                                                      },
                                                       "input": {
                                                         "read": {
                                                           "common": {
-                                                            "direct": {}
+                                                            "direct": {},
+                                                            "hint": {
+                                                              "outputNames": [
+                                                                "l_orderkey",
+                                                                "l_partkey",
+                                                                "l_suppkey",
+                                                                "l_linenumber",
+                                                                "l_quantity",
+                                                                "l_extendedprice",
+                                                                "l_discount",
+                                                                "l_tax",
+                                                                "l_returnflag",
+                                                                "l_linestatus",
+                                                                "l_shipdate",
+                                                                "l_commitdate",
+                                                                "l_receiptdate",
+                                                                "l_shipinstruct",
+                                                                "l_shipmode",
+                                                                "l_comment"
+                                                              ]
+                                                            }
                                                           },
                                                           "baseSchema": {
                                                             "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h16/tpc_h16.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h16/tpc_h16.json
@@ -66,10 +66,53 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "p_brand",
+                  "p_type",
+                  "p_size",
+                  "supplier_cnt"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "p_brand",
+                      "p_type",
+                      "p_size",
+                      "supplier_cnt"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "ps_partkey",
+                          "ps_suppkey",
+                          "ps_availqty",
+                          "ps_supplycost",
+                          "ps_comment",
+                          "p_partkey",
+                          "p_name",
+                          "p_mfgr",
+                          "p_brand",
+                          "p_type",
+                          "p_size",
+                          "p_container",
+                          "p_retailprice",
+                          "p_comment"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -90,6 +133,24 @@
                               26,
                               27
                             ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "ps_partkey",
+                              "ps_suppkey",
+                              "ps_availqty",
+                              "ps_supplycost",
+                              "ps_comment",
+                              "p_partkey",
+                              "p_name",
+                              "p_mfgr",
+                              "p_brand",
+                              "p_type",
+                              "p_size",
+                              "p_container",
+                              "p_retailprice",
+                              "p_comment"
+                            ]
                           }
                         },
                         "input": {
@@ -97,7 +158,16 @@
                             "left": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "ps_partkey",
+                                      "ps_suppkey",
+                                      "ps_availqty",
+                                      "ps_supplycost",
+                                      "ps_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -150,7 +220,20 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "p_partkey",
+                                      "p_name",
+                                      "p_mfgr",
+                                      "p_brand",
+                                      "p_type",
+                                      "p_size",
+                                      "p_container",
+                                      "p_retailprice",
+                                      "p_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -611,14 +694,44 @@
                                                   "outputMapping": [
                                                     7
                                                   ]
+                                                },
+                                                "hint": {
+                                                  "outputNames": [
+                                                    "s_suppkey"
+                                                  ]
                                                 }
                                               },
                                               "input": {
                                                 "filter": {
+                                                  "common": {
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "s_suppkey",
+                                                        "s_name",
+                                                        "s_address",
+                                                        "s_nationkey",
+                                                        "s_phone",
+                                                        "s_acctbal",
+                                                        "s_comment"
+                                                      ]
+                                                    }
+                                                  },
                                                   "input": {
                                                     "read": {
                                                       "common": {
-                                                        "direct": {}
+                                                        "direct": {},
+                                                        "hint": {
+                                                          "outputNames": [
+                                                            "s_suppkey",
+                                                            "s_name",
+                                                            "s_address",
+                                                            "s_nationkey",
+                                                            "s_phone",
+                                                            "s_acctbal",
+                                                            "s_comment"
+                                                          ]
+                                                        }
                                                       },
                                                       "baseSchema": {
                                                         "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h17/tpc_h17.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h17/tpc_h17.json
@@ -74,12 +74,57 @@
                 "outputMapping": [
                   1
                 ]
+              },
+              "hint": {
+                "outputNames": [
+                  "avg_yearly"
+                ]
               }
             },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "avg_yearly"
+                    ]
+                  }
+                },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "l_orderkey",
+                          "l_partkey",
+                          "l_suppkey",
+                          "l_linenumber",
+                          "l_quantity",
+                          "l_extendedprice",
+                          "l_discount",
+                          "l_tax",
+                          "l_returnflag",
+                          "l_linestatus",
+                          "l_shipdate",
+                          "l_commitdate",
+                          "l_receiptdate",
+                          "l_shipinstruct",
+                          "l_shipmode",
+                          "l_comment",
+                          "p_partkey",
+                          "p_name",
+                          "p_mfgr",
+                          "p_brand",
+                          "p_type",
+                          "p_size",
+                          "p_container",
+                          "p_retailprice",
+                          "p_comment"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -111,6 +156,35 @@
                               48,
                               49
                             ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment",
+                              "p_partkey",
+                              "p_name",
+                              "p_mfgr",
+                              "p_brand",
+                              "p_type",
+                              "p_size",
+                              "p_container",
+                              "p_retailprice",
+                              "p_comment"
+                            ]
                           }
                         },
                         "input": {
@@ -118,7 +192,27 @@
                             "left": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "l_orderkey",
+                                      "l_partkey",
+                                      "l_suppkey",
+                                      "l_linenumber",
+                                      "l_quantity",
+                                      "l_extendedprice",
+                                      "l_discount",
+                                      "l_tax",
+                                      "l_returnflag",
+                                      "l_linestatus",
+                                      "l_shipdate",
+                                      "l_commitdate",
+                                      "l_receiptdate",
+                                      "l_shipinstruct",
+                                      "l_shipmode",
+                                      "l_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -243,7 +337,20 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "p_partkey",
+                                      "p_name",
+                                      "p_mfgr",
+                                      "p_brand",
+                                      "p_type",
+                                      "p_size",
+                                      "p_container",
+                                      "p_retailprice",
+                                      "p_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -737,12 +844,63 @@
                                                 "scalar": {
                                                   "input": {
                                                     "aggregate": {
+                                                      "common": {
+                                                        "direct": {},
+                                                        "hint": {
+                                                          "outputNames": [
+                                                            "Mean(l_quantity)"
+                                                          ]
+                                                        }
+                                                      },
                                                       "input": {
                                                         "filter": {
+                                                          "common": {
+                                                            "direct": {},
+                                                            "hint": {
+                                                              "outputNames": [
+                                                                "l_orderkey",
+                                                                "l_partkey",
+                                                                "l_suppkey",
+                                                                "l_linenumber",
+                                                                "l_quantity",
+                                                                "l_extendedprice",
+                                                                "l_discount",
+                                                                "l_tax",
+                                                                "l_returnflag",
+                                                                "l_linestatus",
+                                                                "l_shipdate",
+                                                                "l_commitdate",
+                                                                "l_receiptdate",
+                                                                "l_shipinstruct",
+                                                                "l_shipmode",
+                                                                "l_comment"
+                                                              ]
+                                                            }
+                                                          },
                                                           "input": {
                                                             "read": {
                                                               "common": {
-                                                                "direct": {}
+                                                                "direct": {},
+                                                                "hint": {
+                                                                  "outputNames": [
+                                                                    "l_orderkey",
+                                                                    "l_partkey",
+                                                                    "l_suppkey",
+                                                                    "l_linenumber",
+                                                                    "l_quantity",
+                                                                    "l_extendedprice",
+                                                                    "l_discount",
+                                                                    "l_tax",
+                                                                    "l_returnflag",
+                                                                    "l_linestatus",
+                                                                    "l_shipdate",
+                                                                    "l_commitdate",
+                                                                    "l_receiptdate",
+                                                                    "l_shipinstruct",
+                                                                    "l_shipmode",
+                                                                    "l_comment"
+                                                                  ]
+                                                                }
                                                               },
                                                               "baseSchema": {
                                                                 "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h18/tpc_h18.json
@@ -37,12 +37,91 @@
       "root": {
         "input": {
           "fetch": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "c_name",
+                  "c_custkey",
+                  "o_orderkey",
+                  "o_orderdate",
+                  "o_totalprice",
+                  "sum_qty"
+                ]
+              }
+            },
             "input": {
               "sort": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "c_name",
+                      "c_custkey",
+                      "o_orderkey",
+                      "o_orderdate",
+                      "o_totalprice",
+                      "sum_qty"
+                    ]
+                  }
+                },
                 "input": {
                   "aggregate": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "c_name",
+                          "c_custkey",
+                          "o_orderkey",
+                          "o_orderdate",
+                          "o_totalprice",
+                          "sum_qty"
+                        ]
+                      }
+                    },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "c_custkey",
+                              "c_name",
+                              "c_address",
+                              "c_nationkey",
+                              "c_phone",
+                              "c_acctbal",
+                              "c_mktsegment",
+                              "c_comment",
+                              "o_orderkey",
+                              "o_custkey",
+                              "o_orderstatus",
+                              "o_totalprice",
+                              "o_orderdate",
+                              "o_orderpriority",
+                              "o_clerk",
+                              "o_shippriority",
+                              "o_comment",
+                              "l_orderkey",
+                              "l_partkey",
+                              "l_suppkey",
+                              "l_linenumber",
+                              "l_quantity",
+                              "l_extendedprice",
+                              "l_discount",
+                              "l_tax",
+                              "l_returnflag",
+                              "l_linestatus",
+                              "l_shipdate",
+                              "l_commitdate",
+                              "l_receiptdate",
+                              "l_shipinstruct",
+                              "l_shipmode",
+                              "l_comment"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -82,6 +161,43 @@
                                   64,
                                   65
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "c_custkey",
+                                  "c_name",
+                                  "c_address",
+                                  "c_nationkey",
+                                  "c_phone",
+                                  "c_acctbal",
+                                  "c_mktsegment",
+                                  "c_comment",
+                                  "o_orderkey",
+                                  "o_custkey",
+                                  "o_orderstatus",
+                                  "o_totalprice",
+                                  "o_orderdate",
+                                  "o_orderpriority",
+                                  "o_clerk",
+                                  "o_shippriority",
+                                  "o_comment",
+                                  "l_orderkey",
+                                  "l_partkey",
+                                  "l_suppkey",
+                                  "l_linenumber",
+                                  "l_quantity",
+                                  "l_extendedprice",
+                                  "l_discount",
+                                  "l_tax",
+                                  "l_returnflag",
+                                  "l_linestatus",
+                                  "l_shipdate",
+                                  "l_commitdate",
+                                  "l_receiptdate",
+                                  "l_shipinstruct",
+                                  "l_shipmode",
+                                  "l_comment"
+                                ]
                               }
                             },
                             "input": {
@@ -91,7 +207,19 @@
                                     "left": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "c_custkey",
+                                              "c_name",
+                                              "c_address",
+                                              "c_nationkey",
+                                              "c_phone",
+                                              "c_acctbal",
+                                              "c_mktsegment",
+                                              "c_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -162,7 +290,20 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "o_orderkey",
+                                              "o_custkey",
+                                              "o_orderstatus",
+                                              "o_totalprice",
+                                              "o_orderdate",
+                                              "o_orderpriority",
+                                              "o_clerk",
+                                              "o_shippriority",
+                                              "o_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -276,7 +417,27 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "l_orderkey",
+                                          "l_partkey",
+                                          "l_suppkey",
+                                          "l_linenumber",
+                                          "l_quantity",
+                                          "l_extendedprice",
+                                          "l_discount",
+                                          "l_tax",
+                                          "l_returnflag",
+                                          "l_linestatus",
+                                          "l_shipdate",
+                                          "l_commitdate",
+                                          "l_receiptdate",
+                                          "l_shipinstruct",
+                                          "l_shipmode",
+                                          "l_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -791,16 +952,59 @@
                                       "outputMapping": [
                                         2
                                       ]
+                                    },
+                                    "hint": {
+                                      "outputNames": [
+                                        "l_orderkey"
+                                      ]
                                     }
                                   },
                                   "input": {
                                     "filter": {
+                                      "common": {
+                                        "direct": {},
+                                        "hint": {
+                                          "outputNames": [
+                                            "l_orderkey",
+                                            "qty_sum"
+                                          ]
+                                        }
+                                      },
                                       "input": {
                                         "aggregate": {
+                                          "common": {
+                                            "direct": {},
+                                            "hint": {
+                                              "outputNames": [
+                                                "l_orderkey",
+                                                "qty_sum"
+                                              ]
+                                            }
+                                          },
                                           "input": {
                                             "read": {
                                               "common": {
-                                                "direct": {}
+                                                "direct": {},
+                                                "hint": {
+                                                  "outputNames": [
+                                                    "l_orderkey",
+                                                    "l_partkey",
+                                                    "l_suppkey",
+                                                    "l_linenumber",
+                                                    "l_quantity",
+                                                    "l_extendedprice",
+                                                    "l_discount",
+                                                    "l_tax",
+                                                    "l_returnflag",
+                                                    "l_linestatus",
+                                                    "l_shipdate",
+                                                    "l_commitdate",
+                                                    "l_receiptdate",
+                                                    "l_shipinstruct",
+                                                    "l_shipmode",
+                                                    "l_comment"
+                                                  ]
+                                                }
                                               },
                                               "baseSchema": {
                                                 "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h19/tpc_h19.json
@@ -83,8 +83,48 @@
       "root": {
         "input": {
           "aggregate": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "revenue"
+                ]
+              }
+            },
             "input": {
               "filter": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "l_orderkey",
+                      "l_partkey",
+                      "l_suppkey",
+                      "l_linenumber",
+                      "l_quantity",
+                      "l_extendedprice",
+                      "l_discount",
+                      "l_tax",
+                      "l_returnflag",
+                      "l_linestatus",
+                      "l_shipdate",
+                      "l_commitdate",
+                      "l_receiptdate",
+                      "l_shipinstruct",
+                      "l_shipmode",
+                      "l_comment",
+                      "p_partkey",
+                      "p_name",
+                      "p_mfgr",
+                      "p_brand",
+                      "p_type",
+                      "p_size",
+                      "p_container",
+                      "p_retailprice",
+                      "p_comment"
+                    ]
+                  }
+                },
                 "input": {
                   "project": {
                     "common": {
@@ -116,6 +156,35 @@
                           48,
                           49
                         ]
+                      },
+                      "hint": {
+                        "outputNames": [
+                          "l_orderkey",
+                          "l_partkey",
+                          "l_suppkey",
+                          "l_linenumber",
+                          "l_quantity",
+                          "l_extendedprice",
+                          "l_discount",
+                          "l_tax",
+                          "l_returnflag",
+                          "l_linestatus",
+                          "l_shipdate",
+                          "l_commitdate",
+                          "l_receiptdate",
+                          "l_shipinstruct",
+                          "l_shipmode",
+                          "l_comment",
+                          "p_partkey",
+                          "p_name",
+                          "p_mfgr",
+                          "p_brand",
+                          "p_type",
+                          "p_size",
+                          "p_container",
+                          "p_retailprice",
+                          "p_comment"
+                        ]
                       }
                     },
                     "input": {
@@ -123,7 +192,27 @@
                         "left": {
                           "read": {
                             "common": {
-                              "direct": {}
+                              "direct": {},
+                              "hint": {
+                                "outputNames": [
+                                  "l_orderkey",
+                                  "l_partkey",
+                                  "l_suppkey",
+                                  "l_linenumber",
+                                  "l_quantity",
+                                  "l_extendedprice",
+                                  "l_discount",
+                                  "l_tax",
+                                  "l_returnflag",
+                                  "l_linestatus",
+                                  "l_shipdate",
+                                  "l_commitdate",
+                                  "l_receiptdate",
+                                  "l_shipinstruct",
+                                  "l_shipmode",
+                                  "l_comment"
+                                ]
+                              }
                             },
                             "baseSchema": {
                               "names": [
@@ -248,7 +337,20 @@
                         "right": {
                           "read": {
                             "common": {
-                              "direct": {}
+                              "direct": {},
+                              "hint": {
+                                "outputNames": [
+                                  "p_partkey",
+                                  "p_name",
+                                  "p_mfgr",
+                                  "p_brand",
+                                  "p_type",
+                                  "p_size",
+                                  "p_container",
+                                  "p_retailprice",
+                                  "p_comment"
+                                ]
+                              }
                             },
                             "baseSchema": {
                               "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h20/tpc_h20.json
@@ -80,6 +80,15 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "s_name",
+                  "s_address"
+                ]
+              }
+            },
             "input": {
               "project": {
                 "common": {
@@ -88,10 +97,34 @@
                       11,
                       12
                     ]
+                  },
+                  "hint": {
+                    "outputNames": [
+                      "s_name",
+                      "s_address"
+                    ]
                   }
                 },
                 "input": {
                   "filter": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "s_suppkey",
+                          "s_name",
+                          "s_address",
+                          "s_nationkey",
+                          "s_phone",
+                          "s_acctbal",
+                          "s_comment",
+                          "n_nationkey",
+                          "n_name",
+                          "n_regionkey",
+                          "n_comment"
+                        ]
+                      }
+                    },
                     "input": {
                       "project": {
                         "common": {
@@ -109,6 +142,21 @@
                               20,
                               21
                             ]
+                          },
+                          "hint": {
+                            "outputNames": [
+                              "s_suppkey",
+                              "s_name",
+                              "s_address",
+                              "s_nationkey",
+                              "s_phone",
+                              "s_acctbal",
+                              "s_comment",
+                              "n_nationkey",
+                              "n_name",
+                              "n_regionkey",
+                              "n_comment"
+                            ]
                           }
                         },
                         "input": {
@@ -116,7 +164,18 @@
                             "left": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "s_suppkey",
+                                      "s_name",
+                                      "s_address",
+                                      "s_nationkey",
+                                      "s_phone",
+                                      "s_acctbal",
+                                      "s_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -181,7 +240,15 @@
                             "right": {
                               "read": {
                                 "common": {
-                                  "direct": {}
+                                  "direct": {},
+                                  "hint": {
+                                    "outputNames": [
+                                      "n_nationkey",
+                                      "n_name",
+                                      "n_regionkey",
+                                      "n_comment"
+                                    ]
+                                  }
                                 },
                                 "baseSchema": {
                                   "names": [
@@ -437,14 +504,40 @@
                                           "outputMapping": [
                                             5
                                           ]
+                                        },
+                                        "hint": {
+                                          "outputNames": [
+                                            "ps_suppkey"
+                                          ]
                                         }
                                       },
                                       "input": {
                                         "filter": {
+                                          "common": {
+                                            "direct": {},
+                                            "hint": {
+                                              "outputNames": [
+                                                "ps_partkey",
+                                                "ps_suppkey",
+                                                "ps_availqty",
+                                                "ps_supplycost",
+                                                "ps_comment"
+                                              ]
+                                            }
+                                          },
                                           "input": {
                                             "read": {
                                               "common": {
-                                                "direct": {}
+                                                "direct": {},
+                                                "hint": {
+                                                  "outputNames": [
+                                                    "ps_partkey",
+                                                    "ps_suppkey",
+                                                    "ps_availqty",
+                                                    "ps_supplycost",
+                                                    "ps_comment"
+                                                  ]
+                                                }
                                               },
                                               "baseSchema": {
                                                 "names": [
@@ -524,14 +617,48 @@
                                                                 "outputMapping": [
                                                                   9
                                                                 ]
+                                                              },
+                                                              "hint": {
+                                                                "outputNames": [
+                                                                  "p_partkey"
+                                                                ]
                                                               }
                                                             },
                                                             "input": {
                                                               "filter": {
+                                                                "common": {
+                                                                  "direct": {},
+                                                                  "hint": {
+                                                                    "outputNames": [
+                                                                      "p_partkey",
+                                                                      "p_name",
+                                                                      "p_mfgr",
+                                                                      "p_brand",
+                                                                      "p_type",
+                                                                      "p_size",
+                                                                      "p_container",
+                                                                      "p_retailprice",
+                                                                      "p_comment"
+                                                                    ]
+                                                                  }
+                                                                },
                                                                 "input": {
                                                                   "read": {
                                                                     "common": {
-                                                                      "direct": {}
+                                                                      "direct": {},
+                                                                      "hint": {
+                                                                        "outputNames": [
+                                                                          "p_partkey",
+                                                                          "p_name",
+                                                                          "p_mfgr",
+                                                                          "p_brand",
+                                                                          "p_type",
+                                                                          "p_size",
+                                                                          "p_container",
+                                                                          "p_retailprice",
+                                                                          "p_comment"
+                                                                        ]
+                                                                      }
                                                                     },
                                                                     "baseSchema": {
                                                                       "names": [
@@ -694,12 +821,63 @@
                                                                       "scalar": {
                                                                         "input": {
                                                                           "aggregate": {
+                                                                            "common": {
+                                                                              "direct": {},
+                                                                              "hint": {
+                                                                                "outputNames": [
+                                                                                  "Sum(l_quantity)"
+                                                                                ]
+                                                                              }
+                                                                            },
                                                                             "input": {
                                                                               "filter": {
+                                                                                "common": {
+                                                                                  "direct": {},
+                                                                                  "hint": {
+                                                                                    "outputNames": [
+                                                                                      "l_orderkey",
+                                                                                      "l_partkey",
+                                                                                      "l_suppkey",
+                                                                                      "l_linenumber",
+                                                                                      "l_quantity",
+                                                                                      "l_extendedprice",
+                                                                                      "l_discount",
+                                                                                      "l_tax",
+                                                                                      "l_returnflag",
+                                                                                      "l_linestatus",
+                                                                                      "l_shipdate",
+                                                                                      "l_commitdate",
+                                                                                      "l_receiptdate",
+                                                                                      "l_shipinstruct",
+                                                                                      "l_shipmode",
+                                                                                      "l_comment"
+                                                                                    ]
+                                                                                  }
+                                                                                },
                                                                                 "input": {
                                                                                   "read": {
                                                                                     "common": {
-                                                                                      "direct": {}
+                                                                                      "direct": {},
+                                                                                      "hint": {
+                                                                                        "outputNames": [
+                                                                                          "l_orderkey",
+                                                                                          "l_partkey",
+                                                                                          "l_suppkey",
+                                                                                          "l_linenumber",
+                                                                                          "l_quantity",
+                                                                                          "l_extendedprice",
+                                                                                          "l_discount",
+                                                                                          "l_tax",
+                                                                                          "l_returnflag",
+                                                                                          "l_linestatus",
+                                                                                          "l_shipdate",
+                                                                                          "l_commitdate",
+                                                                                          "l_receiptdate",
+                                                                                          "l_shipinstruct",
+                                                                                          "l_shipmode",
+                                                                                          "l_comment"
+                                                                                        ]
+                                                                                      }
                                                                                     },
                                                                                     "baseSchema": {
                                                                                       "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h21/tpc_h21.json
@@ -62,12 +62,53 @@
       "root": {
         "input": {
           "fetch": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "s_name",
+                  "numwait"
+                ]
+              }
+            },
             "input": {
               "sort": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "s_name",
+                      "numwait"
+                    ]
+                  }
+                },
                 "input": {
                   "aggregate": {
+                    "common": {
+                      "direct": {},
+                      "hint": {
+                        "outputNames": [
+                          "s_name",
+                          "numwait"
+                        ]
+                      }
+                    },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "l1_orderkey",
+                              "o_orderstatus",
+                              "l_receiptdate",
+                              "l_commitdate",
+                              "l1_suppkey",
+                              "s_name",
+                              "n_name"
+                            ]
+                          }
+                        },
                         "input": {
                           "project": {
                             "common": {
@@ -81,6 +122,17 @@
                                   41,
                                   42
                                 ]
+                              },
+                              "hint": {
+                                "outputNames": [
+                                  "l1_orderkey",
+                                  "o_orderstatus",
+                                  "l_receiptdate",
+                                  "l_commitdate",
+                                  "l1_suppkey",
+                                  "s_name",
+                                  "n_name"
+                                ]
                               }
                             },
                             "input": {
@@ -92,7 +144,18 @@
                                         "left": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "s_suppkey",
+                                                  "s_name",
+                                                  "s_address",
+                                                  "s_nationkey",
+                                                  "s_phone",
+                                                  "s_acctbal",
+                                                  "s_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -157,7 +220,27 @@
                                         "right": {
                                           "read": {
                                             "common": {
-                                              "direct": {}
+                                              "direct": {},
+                                              "hint": {
+                                                "outputNames": [
+                                                  "l_orderkey",
+                                                  "l_partkey",
+                                                  "l_suppkey",
+                                                  "l_linenumber",
+                                                  "l_quantity",
+                                                  "l_extendedprice",
+                                                  "l_discount",
+                                                  "l_tax",
+                                                  "l_returnflag",
+                                                  "l_linestatus",
+                                                  "l_shipdate",
+                                                  "l_commitdate",
+                                                  "l_receiptdate",
+                                                  "l_shipinstruct",
+                                                  "l_shipmode",
+                                                  "l_comment"
+                                                ]
+                                              }
                                             },
                                             "baseSchema": {
                                               "names": [
@@ -319,7 +402,20 @@
                                     "right": {
                                       "read": {
                                         "common": {
-                                          "direct": {}
+                                          "direct": {},
+                                          "hint": {
+                                            "outputNames": [
+                                              "o_orderkey",
+                                              "o_custkey",
+                                              "o_orderstatus",
+                                              "o_totalprice",
+                                              "o_orderdate",
+                                              "o_orderpriority",
+                                              "o_clerk",
+                                              "o_shippriority",
+                                              "o_comment"
+                                            ]
+                                          }
                                         },
                                         "baseSchema": {
                                           "names": [
@@ -435,7 +531,15 @@
                                 "right": {
                                   "read": {
                                     "common": {
-                                      "direct": {}
+                                      "direct": {},
+                                      "hint": {
+                                        "outputNames": [
+                                          "n_nationkey",
+                                          "n_name",
+                                          "n_regionkey",
+                                          "n_comment"
+                                        ]
+                                      }
                                     },
                                     "baseSchema": {
                                       "names": [
@@ -748,10 +852,53 @@
                                               "predicateOp": "PREDICATE_OP_EXISTS",
                                               "tuples": {
                                                 "filter": {
+                                                  "common": {
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "l_orderkey",
+                                                        "l_partkey",
+                                                        "l_suppkey",
+                                                        "l_linenumber",
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_tax",
+                                                        "l_returnflag",
+                                                        "l_linestatus",
+                                                        "l_shipdate",
+                                                        "l_commitdate",
+                                                        "l_receiptdate",
+                                                        "l_shipinstruct",
+                                                        "l_shipmode",
+                                                        "l_comment"
+                                                      ]
+                                                    }
+                                                  },
                                                   "input": {
                                                     "read": {
                                                       "common": {
-                                                        "direct": {}
+                                                        "direct": {},
+                                                        "hint": {
+                                                          "outputNames": [
+                                                            "l_orderkey",
+                                                            "l_partkey",
+                                                            "l_suppkey",
+                                                            "l_linenumber",
+                                                            "l_quantity",
+                                                            "l_extendedprice",
+                                                            "l_discount",
+                                                            "l_tax",
+                                                            "l_returnflag",
+                                                            "l_linestatus",
+                                                            "l_shipdate",
+                                                            "l_commitdate",
+                                                            "l_receiptdate",
+                                                            "l_shipinstruct",
+                                                            "l_shipmode",
+                                                            "l_comment"
+                                                          ]
+                                                        }
                                                       },
                                                       "baseSchema": {
                                                         "names": [
@@ -986,10 +1133,53 @@
                                               "predicateOp": "PREDICATE_OP_EXISTS",
                                               "tuples": {
                                                 "filter": {
+                                                  "common": {
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "l_orderkey",
+                                                        "l_partkey",
+                                                        "l_suppkey",
+                                                        "l_linenumber",
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_tax",
+                                                        "l_returnflag",
+                                                        "l_linestatus",
+                                                        "l_shipdate",
+                                                        "l_commitdate",
+                                                        "l_receiptdate",
+                                                        "l_shipinstruct",
+                                                        "l_shipmode",
+                                                        "l_comment"
+                                                      ]
+                                                    }
+                                                  },
                                                   "input": {
                                                     "read": {
                                                       "common": {
-                                                        "direct": {}
+                                                        "direct": {},
+                                                        "hint": {
+                                                          "outputNames": [
+                                                            "l_orderkey",
+                                                            "l_partkey",
+                                                            "l_suppkey",
+                                                            "l_linenumber",
+                                                            "l_quantity",
+                                                            "l_extendedprice",
+                                                            "l_discount",
+                                                            "l_tax",
+                                                            "l_returnflag",
+                                                            "l_linestatus",
+                                                            "l_shipdate",
+                                                            "l_commitdate",
+                                                            "l_receiptdate",
+                                                            "l_shipinstruct",
+                                                            "l_shipmode",
+                                                            "l_comment"
+                                                          ]
+                                                        }
                                                       },
                                                       "baseSchema": {
                                                         "names": [

--- a/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
+++ b/ibis_substrait/tests/compiler/snapshots/test_tpch/test_compile/tpc_h22/tpc_h22.json
@@ -84,8 +84,28 @@
       "root": {
         "input": {
           "sort": {
+            "common": {
+              "direct": {},
+              "hint": {
+                "outputNames": [
+                  "cntrycode",
+                  "numcust",
+                  "totacctbal"
+                ]
+              }
+            },
             "input": {
               "aggregate": {
+                "common": {
+                  "direct": {},
+                  "hint": {
+                    "outputNames": [
+                      "cntrycode",
+                      "numcust",
+                      "totacctbal"
+                    ]
+                  }
+                },
                 "input": {
                   "project": {
                     "common": {
@@ -94,14 +114,47 @@
                           8,
                           9
                         ]
+                      },
+                      "hint": {
+                        "outputNames": [
+                          "cntrycode",
+                          "c_acctbal"
+                        ]
                       }
                     },
                     "input": {
                       "filter": {
+                        "common": {
+                          "direct": {},
+                          "hint": {
+                            "outputNames": [
+                              "c_custkey",
+                              "c_name",
+                              "c_address",
+                              "c_nationkey",
+                              "c_phone",
+                              "c_acctbal",
+                              "c_mktsegment",
+                              "c_comment"
+                            ]
+                          }
+                        },
                         "input": {
                           "read": {
                             "common": {
-                              "direct": {}
+                              "direct": {},
+                              "hint": {
+                                "outputNames": [
+                                  "c_custkey",
+                                  "c_name",
+                                  "c_address",
+                                  "c_nationkey",
+                                  "c_phone",
+                                  "c_acctbal",
+                                  "c_mktsegment",
+                                  "c_comment"
+                                ]
+                              }
                             },
                             "baseSchema": {
                               "names": [
@@ -317,12 +370,47 @@
                                                     "scalar": {
                                                       "input": {
                                                         "aggregate": {
+                                                          "common": {
+                                                            "direct": {},
+                                                            "hint": {
+                                                              "outputNames": [
+                                                                "Mean(c_acctbal)"
+                                                              ]
+                                                            }
+                                                          },
                                                           "input": {
                                                             "filter": {
+                                                              "common": {
+                                                                "direct": {},
+                                                                "hint": {
+                                                                  "outputNames": [
+                                                                    "c_custkey",
+                                                                    "c_name",
+                                                                    "c_address",
+                                                                    "c_nationkey",
+                                                                    "c_phone",
+                                                                    "c_acctbal",
+                                                                    "c_mktsegment",
+                                                                    "c_comment"
+                                                                  ]
+                                                                }
+                                                              },
                                                               "input": {
                                                                 "read": {
                                                                   "common": {
-                                                                    "direct": {}
+                                                                    "direct": {},
+                                                                    "hint": {
+                                                                      "outputNames": [
+                                                                        "c_custkey",
+                                                                        "c_name",
+                                                                        "c_address",
+                                                                        "c_nationkey",
+                                                                        "c_phone",
+                                                                        "c_acctbal",
+                                                                        "c_mktsegment",
+                                                                        "c_comment"
+                                                                      ]
+                                                                    }
                                                                   },
                                                                   "baseSchema": {
                                                                     "names": [
@@ -613,10 +701,39 @@
                                               "predicateOp": "PREDICATE_OP_EXISTS",
                                               "tuples": {
                                                 "filter": {
+                                                  "common": {
+                                                    "direct": {},
+                                                    "hint": {
+                                                      "outputNames": [
+                                                        "o_orderkey",
+                                                        "o_custkey",
+                                                        "o_orderstatus",
+                                                        "o_totalprice",
+                                                        "o_orderdate",
+                                                        "o_orderpriority",
+                                                        "o_clerk",
+                                                        "o_shippriority",
+                                                        "o_comment"
+                                                      ]
+                                                    }
+                                                  },
                                                   "input": {
                                                     "read": {
                                                       "common": {
-                                                        "direct": {}
+                                                        "direct": {},
+                                                        "hint": {
+                                                          "outputNames": [
+                                                            "o_orderkey",
+                                                            "o_custkey",
+                                                            "o_orderstatus",
+                                                            "o_totalprice",
+                                                            "o_orderdate",
+                                                            "o_orderpriority",
+                                                            "o_clerk",
+                                                            "o_shippriority",
+                                                            "o_comment"
+                                                          ]
+                                                        }
                                                       },
                                                       "baseSchema": {
                                                         "names": [

--- a/ibis_substrait/tests/compiler/test_compiler.py
+++ b/ibis_substrait/tests/compiler/test_compiler.py
@@ -109,10 +109,13 @@ def test_translate_table_expansion(compiler):
     result = translate(expr, compiler=compiler)
     expected = {
         "project": {
-            "common": {"emit": {"outputMapping": [2, 3, 4]}},
+            "common": {
+                "emit": {"outputMapping": [2, 3, 4]},
+                "hint": {"outputNames": ["a", "b", "c"]},
+            },
             "input": {
                 "read": {
-                    "common": {"direct": {}},
+                    "common": {"direct": {}, "hint": {"outputNames": ["a", "b"]}},
                     "baseSchema": {
                         "names": ["a", "b"],
                         "struct": {
@@ -187,10 +190,13 @@ def test_emit_mutate_select_all(compiler):
     result = translate(expr, compiler=compiler)
     expected = {
         "project": {
-            "common": {"emit": {"outputMapping": [3, 4, 5, 6]}},
+            "common": {
+                "emit": {"outputMapping": [3, 4, 5, 6]},
+                "hint": {"outputNames": ["a", "b", "c", "d"]},
+            },
             "input": {
                 "read": {
-                    "common": {"direct": {}},
+                    "common": {"direct": {}, "hint": {"outputNames": ["a", "b", "c"]}},
                     "baseSchema": {
                         "names": ["a", "b", "c"],
                         "struct": {


### PR DESCRIPTION
This is first PR to solve #1145 and adds outputNames hint to all Rels except for JoinRel and CrossRel. Join relations need more work to handle name collisions as ibis doesn't do it for every join step as part of JoinChain.